### PR TITLE
feat(integrations): add GET list available and connected integrations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { attestationsRouter } from './routes/attestations.js'
 import { analyticsRouter } from './routes/analytics.js'
 import { healthRouter } from './routes/health.js'
 import businessRoutes from './routes/businesses.js'
+import integrationsRouter from './routes/integrations.js'
 
 const app = express()
 const PORT = process.env.PORT ?? 3000
@@ -15,6 +16,7 @@ app.use('/api/health', healthRouter)
 app.use('/api/attestations', attestationsRouter)
 app.use('/api/businesses', businessRoutes)
 app.use('/api/analytics', analyticsRouter)
+app.use('/api/integrations', integrationsRouter)
 
 app.listen(PORT, () => {
   console.log(`Veritasor API listening on http://localhost:${PORT}`)

--- a/src/repositories/integration.ts
+++ b/src/repositories/integration.ts
@@ -1,0 +1,33 @@
+export interface Integration {
+  id: string;
+  userId: string;
+  type: 'stripe' | 'razorpay' | 'shopify';
+  connectedAt: string;
+}
+
+const integrations: Integration[] = [];
+
+export const integrationRepository = {
+  findByUserId: (userId: string): Integration[] =>
+    integrations.filter((i) => i.userId === userId),
+
+  findByUserIdAndType: (
+    userId: string,
+    type: Integration['type'],
+  ): Integration | null =>
+    integrations.find((i) => i.userId === userId && i.type === type) ?? null,
+
+  create: (
+    userId: string,
+    type: Integration['type'],
+  ): Integration => {
+    const integration: Integration = {
+      id: crypto.randomUUID(),
+      userId,
+      type,
+      connectedAt: new Date().toISOString(),
+    };
+    integrations.push(integration);
+    return integration;
+  },
+};

--- a/src/routes/integrations.ts
+++ b/src/routes/integrations.ts
@@ -1,0 +1,40 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { integrationRepository } from '../repositories/integration.js';
+
+const router = Router();
+
+interface IntegrationType {
+  name: string;
+  slug: 'stripe' | 'razorpay' | 'shopify';
+}
+
+const AVAILABLE_INTEGRATIONS: IntegrationType[] = [
+  { name: 'Stripe', slug: 'stripe' },
+  { name: 'Razorpay', slug: 'razorpay' },
+  { name: 'Shopify', slug: 'shopify' },
+];
+
+// GET /api/integrations - List available and connected integrations
+router.get('/', requireAuth, (req: Request, res: Response) => {
+  const userId = (req as any).userId;
+
+  const connected = integrationRepository.findByUserId(userId);
+  const connectedSlugs = new Set(connected.map((i) => i.type));
+
+  const available = AVAILABLE_INTEGRATIONS.map((integration) => ({
+    ...integration,
+    isConnected: connectedSlugs.has(integration.slug),
+  }));
+
+  res.json({
+    available,
+    connected: connected.map((i) => ({
+      id: i.id,
+      type: i.type,
+      connectedAt: i.connectedAt,
+    })),
+  });
+});
+
+export default router;


### PR DESCRIPTION
Adds a new endpoint that lets authenticated users see which integrations are available and which ones they’ve already connected.

Changes
Added GET /api/integrations (protected with requireAuth)
Added an integration repository to manage integration data
Mounted integrations router in the main server setup

The endpoint returns:
A list of supported integrations
The user’s currently connected integrations

Example response:
{
  "available": [
    { "name": "Stripe", "slug": "stripe", "isConnected": false },
    { "name": "Razorpay", "slug": "razorpay", "isConnected": true },
    { "name": "Shopify", "slug": "shopify", "isConnected": false }
  ],
  "connected": [
    { "id": "...", "type": "razorpay", "connectedAt": "2026-02-25T..." }
  ]
}

Files
src/routes/integrations.ts — route handler
src/repositories/integration.ts — integration data operations
index.ts — mounted integrations router at /api/integrations

Verification
Project builds successfully (npm run build)
Route is mounted and accessible
Endpoint returns available integrations and user connection status correctly.

Closes #11