### PR TITLE
chore(db): add migration for revenue_snapshots table

### DIFF
--- a/src/db/migrations/002_create_revenue_snapshots_table.sql
+++ b/src/db/migrations/002_create_revenue_snapshots_table.sql
@@ -1,0 +1,12 @@
+-- Migration: 002_create_revenue_snapshots_table
+-- Creates revenue_snapshots table (caching/analytics). Idempotent: safe to run once (runner tracks by version).
+
+CREATE TABLE IF NOT EXISTS revenue_snapshots (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id   TEXT NOT NULL,
+  period        TEXT NOT NULL,
+  total_revenue NUMERIC NOT NULL,
+  net_revenue   NUMERIC NOT NULL,
+  currency      TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
Adds a migration that creates the `revenue_snapshots` table for caching or analytics.

Closes #33

## Changes
- **`src/db/migrations/002_create_revenue_snapshots_table.sql`**
  - Table: `revenue_snapshots`
  - Columns: `id` (UUID, PK), `business_id`, `period`, `total_revenue`, `net_revenue`, `currency`, `created_at`
  - Idempotent via `CREATE TABLE IF NOT EXISTS`

## How to run
`npm run migrate` (requires DATABASE_URL and existing migration runner).