### PR TITLE
test(api): consistent error response shape

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -10,6 +10,7 @@
  *   code: string,        // Machine-readable error code
  *   message: string,     // Human-readable message
  *   details?: any,       // Additional error details (validation errors, etc.)
+ *   errors?: any,        // Legacy validation details alias
  *   timestamp: string,   // ISO 8601 timestamp
  *   requestId?: string   // Request ID for tracing (if available)
  * }
@@ -29,19 +30,61 @@
  */
 
 import { Request, Response, NextFunction } from "express";
+import { z } from "zod";
 import {
   ValidationError,
   AppError,
-  AuthenticationError,
-  AuthorizationError,
-  NotFoundError,
-  ConflictError,
-  RateLimitError,
-  DatabaseError,
-  ExternalServiceError,
+  ErrorCodes,
   isAppError,
   isValidationError,
 } from "../types/errors.js";
+
+type ErrorEnvelope = {
+  status: "error";
+  code: string;
+  message: string;
+  timestamp: string;
+  requestId?: string;
+  details?: unknown;
+  errors?: unknown;
+};
+
+type PostgresError = Error & {
+  code?: string;
+  detail?: string;
+  constraint?: string;
+  table?: string;
+  schema?: string;
+};
+
+const CLIENT_SAFE_POSTGRES_CONFLICT_CODES = new Set([
+  "23503", // foreign_key_violation
+  "23505", // unique_violation
+]);
+
+function sanitizeErrorCode(code: string | undefined, fallback: string): string {
+  if (!code || !/^[A-Z0-9_]+$/.test(code)) {
+    return fallback;
+  }
+
+  return code;
+}
+
+function isPostgresError(error: unknown): error is PostgresError {
+  return (
+    error instanceof Error &&
+    typeof (error as PostgresError).code === "string" &&
+    /^[0-9A-Z]{5}$/.test((error as PostgresError).code ?? "")
+  );
+}
+
+function normalizeZodIssues(error: z.ZodError): Array<{ path: string[]; message: string; code: string }> {
+  return error.issues.map((issue) => ({
+    path: issue.path.map(String),
+    message: issue.message,
+    code: issue.code,
+  }));
+}
 
 /**
  * Generates the standardized error envelope
@@ -50,10 +93,10 @@ import {
  * @param requestId - Optional request ID for tracing
  * @returns Standardized error response object
  */
-function createErrorEnvelope(error: unknown, requestId?: string): Record<string, any> {
+function createErrorEnvelope(error: unknown, requestId?: string): ErrorEnvelope {
   const timestamp = new Date().toISOString();
   
-  const baseEnvelope: Record<string, any> = {
+  const baseEnvelope: Omit<ErrorEnvelope, "code" | "message" | "details"> = {
     status: "error",
     timestamp,
   };
@@ -67,9 +110,22 @@ function createErrorEnvelope(error: unknown, requestId?: string): Record<string,
   if (isValidationError(error)) {
     return {
       ...baseEnvelope,
-      code: "VALIDATION_ERROR",
+      code: ErrorCodes.VALIDATION_ERROR,
       message: error.message,
       details: error.details,
+      errors: error.details,
+    };
+  }
+
+  if (error instanceof z.ZodError) {
+    const details = normalizeZodIssues(error);
+
+    return {
+      ...baseEnvelope,
+      code: ErrorCodes.VALIDATION_ERROR,
+      message: "Validation Error",
+      details,
+      errors: details,
     };
   }
   
@@ -79,14 +135,30 @@ function createErrorEnvelope(error: unknown, requestId?: string): Record<string,
     if (error.status >= 500) {
       return {
         ...baseEnvelope,
-        code: error.code,
+        code: sanitizeErrorCode(error.code, ErrorCodes.INTERNAL_SERVER_ERROR),
         message: "An unexpected error occurred",
       };
     }
     return {
       ...baseEnvelope,
-      code: error.code,
+      code: sanitizeErrorCode(error.code, ErrorCodes.INTERNAL_SERVER_ERROR),
       message: error.message,
+    };
+  }
+
+  if (isPostgresError(error)) {
+    if (CLIENT_SAFE_POSTGRES_CONFLICT_CODES.has(error.code ?? "")) {
+      return {
+        ...baseEnvelope,
+        code: ErrorCodes.CONFLICT,
+        message: "Resource conflict",
+      };
+    }
+
+    return {
+      ...baseEnvelope,
+      code: ErrorCodes.DATABASE_ERROR,
+      message: "An unexpected error occurred",
     };
   }
   
@@ -95,7 +167,7 @@ function createErrorEnvelope(error: unknown, requestId?: string): Record<string,
     // Don't expose internal error messages for generic errors
     return {
       ...baseEnvelope,
-      code: "INTERNAL_SERVER_ERROR",
+      code: ErrorCodes.INTERNAL_SERVER_ERROR,
       message: "An unexpected error occurred",
     };
   }
@@ -103,8 +175,8 @@ function createErrorEnvelope(error: unknown, requestId?: string): Record<string,
   // Handle unknown errors
   return {
     ...baseEnvelope,
-    code: "UNKNOWN_ERROR",
-    message: "An unknown error occurred",
+    code: ErrorCodes.INTERNAL_SERVER_ERROR,
+    message: "An unexpected error occurred",
   };
 }
 
@@ -118,9 +190,21 @@ function getStatusCode(error: unknown): number {
   if (isValidationError(error)) {
     return 400;
   }
+
+  if (error instanceof z.ZodError) {
+    return 400;
+  }
   
   if (isAppError(error)) {
     return error.status;
+  }
+
+  if (isPostgresError(error)) {
+    if (CLIENT_SAFE_POSTGRES_CONFLICT_CODES.has(error.code ?? "")) {
+      return 409;
+    }
+
+    return 500;
   }
   
   if (error instanceof Error) {
@@ -156,19 +240,25 @@ export const errorHandler = (
   // Extract request ID if available (set by requestLogger middleware)
   const requestId = res.locals.requestId;
   
-  // Log the error for debugging (use console.error for server-side logging)
-  // In production, this would go to a proper logging service
+  const statusCode = getStatusCode(err);
+  
+  // Log structured server-side context without leaking DB details or request bodies.
   console.error("[Error]", {
-    message: err instanceof Error ? err.message : "Unknown error",
+    level: "error",
+    errorType: err instanceof Error ? err.name : typeof err,
+    message: err instanceof Error ? err.message : "Non-Error throwable",
     stack: err instanceof Error ? err.stack : undefined,
+    errorCode: isAppError(err)
+      ? sanitizeErrorCode(err.code, ErrorCodes.INTERNAL_SERVER_ERROR)
+      : isPostgresError(err)
+        ? err.code
+        : undefined,
+    statusCode,
     path: req.path,
     method: req.method,
     requestId,
     timestamp: new Date().toISOString(),
   });
-  
-  // Determine appropriate status code
-  const statusCode = getStatusCode(err);
   
   // Create standardized error envelope
   const errorEnvelope = createErrorEnvelope(err, requestId);

--- a/tests/README.md
+++ b/tests/README.md
@@ -130,6 +130,38 @@ afterAll(async () => {
 - Test OAuth state validation and expiration
 - Ensure tokens and credentials are not leaked in responses
 
+## Error Envelope Snapshot Coverage
+
+`integration/auth.test.ts` includes snapshot tests for the global error handler
+client shape. These tests pin the stable envelope fields:
+
+- `status: "error"`
+- `code` from `src/types/errors.ts`
+- client-safe `message`
+- optional `details` for validation failures, plus legacy `errors` alias for
+  existing validation clients
+- `timestamp` and `requestId`
+
+The snapshots cover direct Zod errors, PostgreSQL constraint and operational
+errors, and non-`Error` throwables. Timestamps and request IDs are normalized in
+the snapshot helper so the tests assert contract shape rather than runtime
+entropy.
+
+## Threat Model Notes
+
+- **Auth**: login, refresh, password reset, and current-user failures must keep
+  credential, token, and user-enumeration details out of responses. Server-side
+  logs should include request method, path, request ID, status code, and typed
+  error metadata for triage without recording request bodies or secrets.
+- **Webhooks**: malformed payloads, signature failures, replay attempts, and
+  provider downtime should return typed, generic envelopes. Logs may include
+  provider name, request ID, and verification outcome, but never webhook secrets,
+  raw signatures, payment tokens, or full provider payloads.
+- **Integrations**: OAuth state mismatches, token exchange failures, and provider
+  API errors should preserve stable client codes while redacting access tokens,
+  refresh tokens, API keys, merchant credentials, and database connection
+  details from both API responses and routine structured logs.
+
 ## End-to-End (E2E) Testing Plan
 
 The E2E tests verify the complete system flow, including the API, backend services, database, and Soroban contract interactions.

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import request from "supertest";
 import express, { Express } from "express";
+import { z } from "zod";
 import { errorHandler, notFoundHandler } from "../../src/middleware/errorHandler.js";
 import {
   ValidationError,
@@ -102,6 +103,14 @@ function expectErrorEnvelope(
   expect(response.body).toHaveProperty("message");
   expect(response.body).toHaveProperty("timestamp");
   expect(new Date(response.body.timestamp).getTime()).toBeGreaterThan(0);
+}
+
+function normalizeErrorSnapshot(body: any): any {
+  return {
+    ...body,
+    timestamp: "ISO_TIMESTAMP",
+    requestId: body.requestId ? "REQUEST_ID" : undefined,
+  };
 }
 
 /**
@@ -388,6 +397,45 @@ function createMockAuthRouter() {
     } catch (error) {
       next(error);
     }
+  });
+
+  router.post("/zod-error", (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    try {
+      z.object({
+        email: z.string().email(),
+        password: z.string().min(12),
+      }).parse(req.body);
+
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/postgres-conflict", (_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const error = new Error("duplicate key value violates unique constraint \"users_email_key\"") as Error & {
+      code?: string;
+      detail?: string;
+    };
+    error.name = "DatabaseError";
+    error.code = "23505";
+    error.detail = "Key (email)=(private@example.com) already exists.";
+    next(error);
+  });
+
+  router.post("/postgres-error", (_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const error = new Error("connection terminated unexpectedly") as Error & {
+      code?: string;
+      detail?: string;
+    };
+    error.name = "DatabaseError";
+    error.code = "57P01";
+    error.detail = "connection string contained password=super-secret";
+    next(error);
+  });
+
+  router.post("/unknown-throwable", (_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    next({ secret: "do-not-leak" });
   });
 
   return router;
@@ -922,6 +970,111 @@ describe("Error Envelope Standardization", () => {
       .expect(404);
 
     expectErrorEnvelope(response, "NOT_FOUND", 404);
+  });
+
+  describe("snapshot coverage for client error shape", () => {
+    it("should render direct Zod errors as validation envelopes", async () => {
+      const response = await request(app)
+        .post("/api/auth/zod-error")
+        .send({ email: "not-an-email", password: "short" })
+        .expect(400);
+
+      expect(normalizeErrorSnapshot(response.body)).toMatchInlineSnapshot(`
+        {
+          "code": "VALIDATION_ERROR",
+          "details": [
+            {
+              "code": "invalid_string",
+              "message": "Invalid email",
+              "path": [
+                "email",
+              ],
+            },
+            {
+              "code": "too_small",
+              "message": "String must contain at least 12 character(s)",
+              "path": [
+                "password",
+              ],
+            },
+          ],
+          "errors": [
+            {
+              "code": "invalid_string",
+              "message": "Invalid email",
+              "path": [
+                "email",
+              ],
+            },
+            {
+              "code": "too_small",
+              "message": "String must contain at least 12 character(s)",
+              "path": [
+                "password",
+              ],
+            },
+          ],
+          "message": "Validation Error",
+          "requestId": "REQUEST_ID",
+          "status": "error",
+          "timestamp": "ISO_TIMESTAMP",
+        }
+      `);
+    });
+
+    it("should render PostgreSQL constraint errors without leaking row details", async () => {
+      const response = await request(app)
+        .post("/api/auth/postgres-conflict")
+        .send({})
+        .expect(409);
+
+      expect(normalizeErrorSnapshot(response.body)).toMatchInlineSnapshot(`
+        {
+          "code": "CONFLICT",
+          "message": "Resource conflict",
+          "requestId": "REQUEST_ID",
+          "status": "error",
+          "timestamp": "ISO_TIMESTAMP",
+        }
+      `);
+      expect(JSON.stringify(response.body)).not.toMatch(/private@example\\.com|users_email_key/i);
+    });
+
+    it("should render PostgreSQL operational errors as generic database errors", async () => {
+      const response = await request(app)
+        .post("/api/auth/postgres-error")
+        .send({})
+        .expect(500);
+
+      expect(normalizeErrorSnapshot(response.body)).toMatchInlineSnapshot(`
+        {
+          "code": "DATABASE_ERROR",
+          "message": "An unexpected error occurred",
+          "requestId": "REQUEST_ID",
+          "status": "error",
+          "timestamp": "ISO_TIMESTAMP",
+        }
+      `);
+      expect(JSON.stringify(response.body)).not.toMatch(/password=super-secret|connection terminated/i);
+    });
+
+    it("should render unknown throwables as generic internal server errors", async () => {
+      const response = await request(app)
+        .post("/api/auth/unknown-throwable")
+        .send({})
+        .expect(500);
+
+      expect(normalizeErrorSnapshot(response.body)).toMatchInlineSnapshot(`
+        {
+          "code": "INTERNAL_SERVER_ERROR",
+          "message": "An unexpected error occurred",
+          "requestId": "REQUEST_ID",
+          "status": "error",
+          "timestamp": "ISO_TIMESTAMP",
+        }
+      `);
+      expect(JSON.stringify(response.body)).not.toMatch(/do-not-leak/i);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #233

---

Implemented on branch test/errors-consistent-client-shape.

Changed errorHandler.ts (line 32) to align with src/types/errors.ts codes: direct Zod errors now return VALIDATION_ERROR, Postgres constraint errors map to CONFLICT, Postgres operational errors map to DATABASE_ERROR, and unknown throwables collapse to INTERNAL_SERVER_ERROR. Validation responses now include both details and legacy errors for client compatibility, and logging is structured without request bodies or DB detail leakage.

Added snapshot coverage in auth.test.ts (line 975) for Zod, Postgres conflict, Postgres operational, and unknown throwable cases. Updated tests/README.md (line 133) with envelope snapshot notes and threat model notes for auth, webhooks, and integrations.

Verification:
npm test -- tests/integration/auth.test.ts tests/unit/middleware/validate.test.ts
Test Files  2 passed (2)
Tests       65 passed (65)
Full suite still fails in unrelated existing areas:

npm test
Test Files  10 failed | 20 passed (30)
Tests       46 failed | 635 passed | 1 skipped (682)
Representative failures include parse errors in src/app.ts, duplicate declarations in Shopify/signup tests, missing raw helper in revenue normalizer tests, and fc.hexaString is not a function