### PR TITLE
chore: add merkle perf guardrails, timing logs, and complexity docs

### DIFF
--- a/src/services/merkle.ts
+++ b/src/services/merkle.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+import { MERKLE_MAX_LEAVES } from './merkle/generateProof.js';
 
 function sha(data: Buffer): Buffer {
   return crypto.createHash('sha256').update(data).digest();
@@ -12,9 +14,17 @@ export class MerkleTree {
       throw new Error('MerkleTree requires at least one leaf');
     }
 
+    if (leaves.length > MERKLE_MAX_LEAVES) {
+      throw new Error(
+        `leaf count ${leaves.length} exceeds MERKLE_MAX_LEAVES (${MERKLE_MAX_LEAVES})`
+      );
+    }
+
     if (leaves.some((l) => (typeof l === 'string' && l.length === 0))) {
       throw new Error('MerkleTree leaf values must be non-empty strings');
     }
+
+    const t0 = performance.now();
 
     // level 0 = hashed leaves
     this.levels[0] = leaves.map((l) =>
@@ -33,6 +43,16 @@ export class MerkleTree {
       this.levels.unshift(next); // put at front so root becomes levels[0]
       level = next;
     }
+
+    const durationMs = performance.now() - t0;
+    logger.info(
+      JSON.stringify({
+        event: 'merkle.buildTree',
+        leafCount: leaves.length,
+        levels: this.levels.length,
+        durationMs: Math.round(durationMs * 100) / 100,
+      })
+    );
   }
 
   getRoot(): string {

--- a/src/services/merkle/generateProof.ts
+++ b/src/services/merkle/generateProof.ts
@@ -1,4 +1,5 @@
 import { hash } from "./buildTree.js";
+import { logger } from "../../utils/logger.js";
 
 /**
  * Proof format:
@@ -18,6 +19,16 @@ export type Proof = ProofStep[];
  * @dev 256 steps supports trees up to 2^256 leaves and caps CPU work.
  */
 export const MERKLE_PROOF_MAX_STEPS = 256;
+
+/**
+ * @notice Hard cap on leaf count for proof generation.
+ * @dev A tree of 2^20 (~1 M) leaves requires ~20 hashes per proof and
+ *      ~1 M SHA-256 calls to build — well within a single request budget.
+ *      Beyond this the memory footprint (storing all levels) grows linearly
+ *      and risks OOM / request-timeout under concurrent load.
+ *      Complexity: O(n) time and space to build, O(log n) per proof.
+ */
+export const MERKLE_MAX_LEAVES = 1_048_576; // 2^20
 
 const HASH_HEX_REGEX = /^[0-9a-f]{64}$/i;
 
@@ -66,10 +77,16 @@ export function isProof(value: unknown): value is Proof {
 /**
  * @notice Generate a Merkle proof for a leaf at a specific index.
  * @dev Guards validate inputs to prevent malformed proofs.
+ *      Complexity: O(n log n) time, O(n) space (n = leaves.length).
  */
 export function generateProof(leaves: string[], leafIndex: number): Proof {
   if (!Array.isArray(leaves) || leaves.length === 0) {
     throw new Error("leaves must be a non-empty array of strings");
+  }
+  if (leaves.length > MERKLE_MAX_LEAVES) {
+    throw new Error(
+      `leaf count ${leaves.length} exceeds MERKLE_MAX_LEAVES (${MERKLE_MAX_LEAVES})`
+    );
   }
   for (const leaf of leaves) {
     if (typeof leaf !== "string") {
@@ -82,6 +99,8 @@ export function generateProof(leaves: string[], leafIndex: number): Proof {
   if (leafIndex < 0 || leafIndex >= leaves.length) {
     throw new Error("leafIndex out of range");
   }
+
+  const t0 = performance.now();
 
   let level: string[] = leaves.map((l) => hash(l));
   let index = leafIndex;
@@ -107,6 +126,17 @@ export function generateProof(leaves: string[], leafIndex: number): Proof {
     level = next;
     index = Math.floor(index / 2);
   }
+
+  const durationMs = performance.now() - t0;
+  logger.info(
+    JSON.stringify({
+      event: "merkle.generateProof",
+      leafCount: leaves.length,
+      leafIndex,
+      proofSteps: proof.length,
+      durationMs: Math.round(durationMs * 100) / 100,
+    })
+  );
 
   return proof;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -184,3 +184,46 @@ The following security assumptions are baked into the system and must be validat
 4. **Idempotency Integrity**:
     - *Assumption*: Multiple identical requests do not result in multiple on-chain transactions (saving gas/fees).
     - *Validation*: Check local database for single record entry after multiple POST bursts.
+
+## Merkle Service — Complexity Notes & Threat Model
+
+### Algorithmic complexity
+
+| Operation | Time | Space | Notes |
+|-----------|------|-------|-------|
+| `MerkleTree` constructor | O(n) | O(n) | n = leaf count; all levels stored in memory |
+| `MerkleTree.getProof` | O(log n) | O(log n) | Traverses stored levels |
+| `MerkleTree.verifyProof` | O(log n) | O(1) | Re-hashes along the proof path |
+| `generateProof` (standalone) | O(n log n) | O(n) | Rebuilds each level on the fly |
+| `verifyProof` (standalone) | O(log n) | O(1) | |
+
+### Hard limits
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `MERKLE_MAX_LEAVES` | 2²⁰ (1 048 576) | ~1 M SHA-256 calls to build; linear memory; safe within a single request |
+| `MERKLE_PROOF_MAX_STEPS` | 256 | Caps verification CPU; supports trees up to 2²⁵⁶ leaves |
+
+Both constants are exported from `src/services/merkle/generateProof.ts` and enforced at the top of every entry point before any allocation occurs.
+
+### Threat model
+
+**Deep-tree / large-leaf DoS**
+- *Risk*: A caller supplies millions of leaves, causing OOM or request timeout.
+- *Mitigation*: `MERKLE_MAX_LEAVES` guard throws before any hashing. Callers should also enforce this limit at the HTTP layer (Zod schema on the request body).
+
+**Proof-length amplification**
+- *Risk*: A crafted proof with thousands of steps forces the verifier into a long loop.
+- *Mitigation*: `MERKLE_PROOF_MAX_STEPS = 256` guard in `isProof()` rejects oversized proofs before the loop runs.
+
+**Hash-collision / second-preimage**
+- *Risk*: An attacker forges a leaf that hashes to the same value as a legitimate leaf.
+- *Mitigation*: SHA-256 is used throughout; no known practical collision attacks. Leaf values are hashed before tree construction, so raw input is never compared directly.
+
+**Log injection**
+- *Risk*: Leaf content containing newlines or JSON control characters pollutes structured logs.
+- *Mitigation*: Only metadata (counts, indices, timing) is logged — never raw leaf values. `JSON.stringify` escapes all control characters.
+
+**Timing side-channels**
+- *Risk*: Proof generation time leaks information about tree depth or leaf position.
+- *Mitigation*: Proof depth is `ceil(log₂(n))` regardless of leaf index; timing is logged for observability, not returned to callers.

--- a/tests/unit/services/merkle.test.ts
+++ b/tests/unit/services/merkle.test.ts
@@ -4,6 +4,7 @@ import { buildTree, getRoot } from '../../../src/services/merkle/buildTree'
 import {
   generateProof,
   verifyProof,
+  MERKLE_MAX_LEAVES,
   MERKLE_PROOF_MAX_STEPS,
 } from '../../../src/services/merkle/generateProof'
 
@@ -36,6 +37,33 @@ describe('MerkleTree', () => {
     }
     const bad = MerkleTree.verifyProof(leaves[index], badProof, root, index)
     expect(bad).toBe(false)
+  })
+
+  // --- perf / guard cases ---
+
+  it('rejects leaf count above MERKLE_MAX_LEAVES', () => {
+    // Build a stub array that reports a length above the cap without allocating 1M strings.
+    const oversized = { length: MERKLE_MAX_LEAVES + 1, [Symbol.iterator]: [][Symbol.iterator] } as unknown as string[]
+    // MerkleTree checks leaves.length before iterating, so this is safe.
+    expect(() => new MerkleTree(oversized as any)).toThrow(/MERKLE_MAX_LEAVES/)
+  })
+
+  it('completes a 1 000-leaf tree within 500 ms', () => {
+    const big = Array.from({ length: 1_000 }, (_, i) => `leaf-${i}`)
+    const t0 = performance.now()
+    const tree = new MerkleTree(big)
+    const elapsed = performance.now() - t0
+    expect(tree.getRoot()).toHaveLength(64)
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('proof depth is O(log n) for a 1 024-leaf tree', () => {
+    const n = 1_024
+    const big = Array.from({ length: n }, (_, i) => `leaf-${i}`)
+    const tree = new MerkleTree(big)
+    const proof = tree.getProof(0)
+    // log2(1024) = 10
+    expect(proof.length).toBe(Math.ceil(Math.log2(n)))
   })
 })
 
@@ -89,5 +117,37 @@ describe('MerkleProofGuards', () => {
 
   it('throws on non-integer leaf index', () => {
     expect(() => generateProof(leaves, 1.5)).toThrow(/integer/i)
+  })
+
+  // --- perf / guard cases ---
+
+  it('rejects leaf count above MERKLE_MAX_LEAVES', () => {
+    const oversized = new Array(MERKLE_MAX_LEAVES + 1).fill('x')
+    expect(() => generateProof(oversized, 0)).toThrow(/MERKLE_MAX_LEAVES/)
+  })
+
+  it('generateProof completes a 1 000-leaf proof within 500 ms', () => {
+    const big = Array.from({ length: 1_000 }, (_, i) => `leaf-${i}`)
+    const t0 = performance.now()
+    const proof = generateProof(big, 0)
+    const elapsed = performance.now() - t0
+    expect(proof.length).toBeGreaterThan(0)
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('proof depth is O(log n) for 1 024 leaves', () => {
+    const n = 1_024
+    const big = Array.from({ length: n }, (_, i) => `leaf-${i}`)
+    const proof = generateProof(big, 0)
+    expect(proof.length).toBe(Math.ceil(Math.log2(n)))
+  })
+
+  it('verifyProof round-trips a large proof correctly', () => {
+    const big = Array.from({ length: 256 }, (_, i) => `leaf-${i}`)
+    const bigTree = buildTree(big)
+    const bigRoot = getRoot(bigTree, big.length)
+    const index = 127
+    const proof = generateProof(big, index)
+    expect(verifyProof(big[index], proof, bigRoot)).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #237 

- Export MERKLE_MAX_LEAVES (2^20) cap; guard throws before any allocation
- Add performance.now() timing + structured JSON logs in both MerkleTree constructor and generateProof()
- Extend merkle tests: MAX_LEAVES rejection, 1k-leaf timing (<500ms), O(log n) proof depth, large round-trip verify
- Document complexity table, hard limits, and threat model in tests/README.md