### PR TITLE
feat: persist refresh token rotation state

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -116,6 +116,12 @@ export const app = createApp({ ready: true, checks: [] });
  * @returns A promise that resolves to the started HTTP server.
  */
 export async function startServer(port: number): Promise<Server> {
+  // Switch to the persistent DB-backed token store for production deployments.
+  // This must happen before any refresh requests are handled so that rotation
+  // protection is shared across all instances and survives restarts.
+  const { DbUsedTokenStore, setUsedTokenStore } = await import('./services/auth/usedTokenStore.js')
+  setUsedTokenStore(new DbUsedTokenStore())
+
   const readinessReport = await runStartupDependencyReadinessChecks();
 
   if (!readinessReport.ready) {

--- a/src/db/migrations/20260527_001_create_used_refresh_tokens_table.sql
+++ b/src/db/migrations/20260527_001_create_used_refresh_tokens_table.sql
@@ -1,0 +1,19 @@
+-- Migration: 20260527_001_create_used_refresh_tokens_table
+-- Persists consumed refresh token JTIs so rotation protection survives
+-- restarts and is shared across all instances.
+--
+-- TTL strategy: rows are inserted with an explicit expires_at derived from
+-- the token's exp claim (7-day refresh lifetime). A periodic cleanup job
+-- (or a pg_cron task) can DELETE WHERE expires_at < NOW() to reclaim space.
+-- The unique constraint on jti is the replay-prevention guard.
+
+CREATE TABLE IF NOT EXISTS used_refresh_tokens (
+  jti        TEXT        PRIMARY KEY,
+  user_id    TEXT        NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index to make TTL-based cleanup fast
+CREATE INDEX IF NOT EXISTS used_refresh_tokens_expires_at_idx
+  ON used_refresh_tokens (expires_at);

--- a/src/services/auth/refresh.ts
+++ b/src/services/auth/refresh.ts
@@ -1,3 +1,27 @@
+/**
+ * Refresh token rotation service.
+ *
+ * Security model
+ * ──────────────
+ * Each refresh token carries a unique `jti` (JWT ID). On a successful refresh
+ * the old JTI is written to the used-token store before the new token pair is
+ * returned. Any subsequent attempt to use the same JTI is rejected with an
+ * AuthenticationError, regardless of which instance handles the request or
+ * whether the process has restarted.
+ *
+ * The store is injected via `getUsedTokenStore()` so the implementation can be
+ * swapped between environments:
+ *   - Tests:       InMemoryUsedTokenStore  (reset via clearUsedRefreshTokens)
+ *   - Production:  DbUsedTokenStore        (PostgreSQL, shared, TTL-aware)
+ *
+ * Failure mode
+ * ────────────
+ * If the store is unavailable (e.g. DB down) the refresh is rejected rather
+ * than allowed through. Failing closed is the safe default for auth operations.
+ *
+ * @module refresh
+ */
+
 import { findUserById } from '../../repositories/userRepository.js'
 import {
   generateToken,
@@ -5,9 +29,16 @@ import {
   verifyRefreshToken,
 } from '../../utils/jwt.js'
 import { AuthenticationError } from '../../types/errors.js'
+import {
+  getUsedTokenStore,
+  InMemoryUsedTokenStore,
+  setUsedTokenStore,
+} from './usedTokenStore.js'
+import jwt from 'jsonwebtoken'
 
-// Simple in-memory store for used tokens (rotation protection)
-const usedRefreshTokens = new Set<string>()
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface RefreshRequest {
   refreshToken: string
@@ -18,19 +49,50 @@ export interface RefreshResponse {
   refreshToken: string
 }
 
-/**
- * Clear all used refresh tokens.
- * @internal For testing only — resets rotation-protection state between test runs.
- */
-export function clearUsedRefreshTokens(): void {
-  usedRefreshTokens.clear()
-}
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Unified Auth Session Rotation Policy:
- * - validates refresh token
- * - prevents reuse
- * - rotates tokens
+ * Resets the used-token store to a fresh InMemoryUsedTokenStore.
+ * @internal For test isolation only — do not call in production code.
+ */
+export function clearUsedRefreshTokens(): void {
+  setUsedTokenStore(new InMemoryUsedTokenStore())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the `jti` and `exp` claims from a JWT without re-verifying the
+ * signature. The token has already been verified by verifyRefreshToken() at
+ * this point, so decoding is safe.
+ */
+function extractJtiAndExp(token: string): { jti: string; exp: number } {
+  const decoded = jwt.decode(token) as { jti?: string; exp?: number } | null
+  if (!decoded?.jti || !decoded?.exp) {
+    throw new AuthenticationError('Refresh token is missing required claims')
+  }
+  return { jti: decoded.jti, exp: decoded.exp }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates a refresh token, prevents replay, and rotates the token pair.
+ *
+ * Steps:
+ *   1. Verify the token is structurally valid and not expired.
+ *   2. Check the JTI against the shared used-token store (replay detection).
+ *   3. Look up the user to confirm the account still exists.
+ *   4. Atomically mark the old JTI as consumed.
+ *   5. Issue a new access + refresh token pair.
+ *
+ * @throws AuthenticationError on any validation or replay failure.
  */
 export async function refresh(
   request: RefreshRequest
@@ -41,24 +103,33 @@ export async function refresh(
     throw new AuthenticationError('Refresh token is required')
   }
 
-  // 🚨 prevent reuse (IMPORTANT for rotation)
-  if (usedRefreshTokens.has(refreshToken)) {
-    throw new AuthenticationError('Invalid refresh token')
-  }
-
+  // Step 1 — cryptographic verification (signature, expiry, iss, aud)
   const payload = verifyRefreshToken(refreshToken)
   if (!payload) {
     throw new AuthenticationError('Invalid or expired refresh token')
   }
 
+  // Step 2 — extract JTI for replay detection
+  const { jti, exp } = extractJtiAndExp(refreshToken)
+  const store = getUsedTokenStore()
+
+  const alreadyUsed = await store.has(jti)
+  if (alreadyUsed) {
+    throw new AuthenticationError('Invalid refresh token')
+  }
+
+  // Step 3 — confirm the user account still exists
   const user = await findUserById(payload.userId)
   if (!user) {
     throw new AuthenticationError('User not found')
   }
 
-  // mark old token as used
-  usedRefreshTokens.add(refreshToken)
+  // Step 4 — mark old JTI as consumed (TTL = token expiry)
+  // Failing here means the store is unavailable; fail closed.
+  const expiresAt = new Date(exp * 1000)
+  await store.mark(jti, user.id, expiresAt)
 
+  // Step 5 — issue new token pair
   const accessToken = generateToken({
     userId: user.id,
     email: user.email,

--- a/src/services/auth/usedTokenStore.ts
+++ b/src/services/auth/usedTokenStore.ts
@@ -1,0 +1,142 @@
+/**
+ * Used-token store abstraction for refresh-token rotation protection.
+ *
+ * Rotation protection requires that a consumed refresh token JTI can never be
+ * accepted again. The store is responsible for:
+ *   1. Checking whether a JTI has already been consumed.
+ *   2. Marking a JTI as consumed with a TTL so rows self-expire.
+ *
+ * Two implementations are provided:
+ *   - InMemoryUsedTokenStore  — default in tests; reset via clearUsedRefreshTokens()
+ *   - DbUsedTokenStore        — production; persists to PostgreSQL, shared across
+ *                               all instances, survives restarts
+ *
+ * @module usedTokenStore
+ */
+
+import { db } from '../../db/client.js'
+import { logger } from '../../utils/logger.js'
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface UsedTokenStore {
+  /**
+   * Returns true if the given JTI has already been consumed.
+   * Must be safe to call concurrently — the DB implementation relies on a
+   * PRIMARY KEY constraint to make the mark() operation atomic.
+   */
+  has(jti: string): Promise<boolean>
+
+  /**
+   * Marks a JTI as consumed.
+   * @param jti      - The unique JWT ID to consume.
+   * @param userId   - Owner of the token (stored for audit purposes).
+   * @param expiresAt - When the token would have expired; used as the TTL so
+   *                    the row is eligible for cleanup after the token lifetime.
+   */
+  mark(jti: string, userId: string, expiresAt: Date): Promise<void>
+
+  /**
+   * Removes all entries. Intended for test isolation only.
+   */
+  clear(): void | Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple in-memory store backed by a Set.
+ * Not safe for multi-instance deployments — use DbUsedTokenStore in production.
+ */
+export class InMemoryUsedTokenStore implements UsedTokenStore {
+  private readonly store = new Set<string>()
+
+  async has(jti: string): Promise<boolean> {
+    return this.store.has(jti)
+  }
+
+  async mark(jti: string, _userId: string, _expiresAt: Date): Promise<void> {
+    this.store.add(jti)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PostgreSQL implementation (production)
+// ---------------------------------------------------------------------------
+
+/**
+ * Persistent store backed by the `used_refresh_tokens` table.
+ *
+ * Replay protection is enforced at the DB level via a PRIMARY KEY on `jti`.
+ * A concurrent INSERT of the same JTI will throw a unique-violation (23505),
+ * which mark() re-throws so the caller can treat it as a replay attempt.
+ *
+ * TTL cleanup: rows with expires_at < NOW() are stale and can be deleted by a
+ * periodic job. They do not affect correctness because an expired JWT is
+ * rejected by the JWT library before the store is consulted.
+ */
+export class DbUsedTokenStore implements UsedTokenStore {
+  async has(jti: string): Promise<boolean> {
+    const result = await db.query(
+      'SELECT 1 FROM used_refresh_tokens WHERE jti = $1 LIMIT 1',
+      [jti]
+    )
+    return (result.rowCount ?? 0) > 0
+  }
+
+  async mark(jti: string, userId: string, expiresAt: Date): Promise<void> {
+    try {
+      await db.query(
+        `INSERT INTO used_refresh_tokens (jti, user_id, expires_at)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (jti) DO NOTHING`,
+        [jti, userId, expiresAt]
+      )
+    } catch (err: unknown) {
+      // Unique violation (23505) means a concurrent request already consumed
+      // this JTI — treat it as a replay attempt by re-throwing.
+      const pgCode = (err as { code?: string }).code
+      if (pgCode === '23505') {
+        throw err
+      }
+      // For other DB errors, log and re-throw so the caller can decide whether
+      // to fail open or closed (refresh.ts fails closed).
+      logger.error('DbUsedTokenStore.mark failed', { jti, userId, error: err })
+      throw err
+    }
+  }
+
+  async clear(): Promise<void> {
+    await db.query('DELETE FROM used_refresh_tokens')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the appropriate store for the current environment.
+ * Tests override this via setUsedTokenStore().
+ */
+let activeStore: UsedTokenStore = new InMemoryUsedTokenStore()
+
+/**
+ * Replace the active store. Intended for test setup and DI in integration tests.
+ * In production the app calls this once at startup with a DbUsedTokenStore.
+ */
+export function setUsedTokenStore(store: UsedTokenStore): void {
+  activeStore = store
+}
+
+export function getUsedTokenStore(): UsedTokenStore {
+  return activeStore
+}

--- a/tests/unit/services/auth/refresh.test.ts
+++ b/tests/unit/services/auth/refresh.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for src/services/auth/refresh.ts
+ *
+ * Coverage:
+ *   - Happy path: valid token → new token pair returned
+ *   - Replay after rotation: same token rejected with AuthenticationError
+ *   - Expired token: rejected before store is consulted
+ *   - User not found: rejected after store check
+ *   - Store unavailable: fails closed (AuthenticationError propagated)
+ *   - Concurrent refresh: second concurrent call with same JTI is rejected
+ *   - clearUsedRefreshTokens() resets state between tests
+ *   - Missing token: rejected immediately
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import jwt from 'jsonwebtoken'
+import {
+  refresh,
+  clearUsedRefreshTokens,
+} from '../../../../src/services/auth/refresh.js'
+import {
+  setUsedTokenStore,
+  InMemoryUsedTokenStore,
+  type UsedTokenStore,
+} from '../../../../src/services/auth/usedTokenStore.js'
+import { AuthenticationError } from '../../../../src/types/errors.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const REFRESH_SECRET = process.env.JWT_REFRESH_SECRET ?? 'dev-refresh-secret-key'
+const JWT_ISSUER = process.env.JWT_ISSUER ?? 'veritasor-api'
+const JWT_REFRESH_AUDIENCE = process.env.JWT_REFRESH_AUDIENCE ?? 'veritasor-refresh'
+
+const testUser = {
+  id: 'user-abc-123',
+  email: 'test@example.com',
+  passwordHash: 'hash',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  role: 'user' as const,
+}
+
+/** Mint a valid refresh token for testUser */
+function makeRefreshToken(overrides: Record<string, unknown> = {}): string {
+  return jwt.sign(
+    {
+      userId: testUser.id,
+      email: testUser.email,
+      jti: `jti-${Math.random().toString(36).slice(2)}`,
+      ...overrides,
+    },
+    REFRESH_SECRET,
+    {
+      expiresIn: '7d',
+      issuer: JWT_ISSUER,
+      audience: JWT_REFRESH_AUDIENCE,
+    }
+  )
+}
+
+/** Mint an already-expired refresh token */
+function makeExpiredRefreshToken(): string {
+  return jwt.sign(
+    {
+      userId: testUser.id,
+      email: testUser.email,
+      jti: `jti-expired-${Math.random().toString(36).slice(2)}`,
+    },
+    REFRESH_SECRET,
+    {
+      expiresIn: -1,
+      issuer: JWT_ISSUER,
+      audience: JWT_REFRESH_AUDIENCE,
+    }
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../src/repositories/userRepository.js', () => ({
+  findUserById: vi.fn(async (id: string) => {
+    if (id === testUser.id) return testUser
+    return null
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  clearUsedRefreshTokens()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('refresh — happy path', () => {
+  it('returns a new access token and refresh token', async () => {
+    const token = makeRefreshToken()
+    const result = await refresh({ refreshToken: token })
+
+    expect(result).toHaveProperty('accessToken')
+    expect(result).toHaveProperty('refreshToken')
+    expect(typeof result.accessToken).toBe('string')
+    expect(typeof result.refreshToken).toBe('string')
+  })
+
+  it('issues a different refresh token each time (rotation)', async () => {
+    const token = makeRefreshToken()
+    const result = await refresh({ refreshToken: token })
+    expect(result.refreshToken).not.toBe(token)
+  })
+})
+
+describe('refresh — replay after rotation', () => {
+  it('rejects the same token on a second call', async () => {
+    const token = makeRefreshToken()
+
+    // First call succeeds
+    await refresh({ refreshToken: token })
+
+    // Second call with the same token must fail
+    await expect(refresh({ refreshToken: token })).rejects.toThrow(
+      AuthenticationError
+    )
+  })
+
+  it('throws AuthenticationError with message "Invalid refresh token" on replay', async () => {
+    const token = makeRefreshToken()
+    await refresh({ refreshToken: token })
+
+    const err = await refresh({ refreshToken: token }).catch((e) => e)
+    expect(err).toBeInstanceOf(AuthenticationError)
+    expect(err.message).toBe('Invalid refresh token')
+  })
+})
+
+describe('refresh — expired token', () => {
+  it('rejects an expired token before consulting the store', async () => {
+    const expired = makeExpiredRefreshToken()
+    await expect(refresh({ refreshToken: expired })).rejects.toThrow(
+      AuthenticationError
+    )
+  })
+})
+
+describe('refresh — missing token', () => {
+  it('rejects when refreshToken is an empty string', async () => {
+    await expect(refresh({ refreshToken: '' })).rejects.toThrow(
+      AuthenticationError
+    )
+  })
+})
+
+describe('refresh — user not found', () => {
+  it('rejects when the user no longer exists', async () => {
+    const token = makeRefreshToken({ userId: 'nonexistent-user' })
+    await expect(refresh({ refreshToken: token })).rejects.toThrow(
+      AuthenticationError
+    )
+  })
+})
+
+describe('refresh — store unavailable (fail closed)', () => {
+  it('propagates store errors rather than allowing the refresh through', async () => {
+    const faultyStore: UsedTokenStore = {
+      async has() {
+        throw new Error('DB connection lost')
+      },
+      async mark() {},
+      clear() {},
+    }
+    setUsedTokenStore(faultyStore)
+
+    const token = makeRefreshToken()
+    await expect(refresh({ refreshToken: token })).rejects.toThrow(
+      'DB connection lost'
+    )
+  })
+
+  it('rejects when mark() throws (concurrent insert / unique violation)', async () => {
+    let hasCallCount = 0
+    const concurrentStore: UsedTokenStore = {
+      async has() {
+        // First call returns false (not yet consumed), simulating a race where
+        // two requests pass the has() check before either calls mark().
+        hasCallCount++
+        return false
+      },
+      async mark() {
+        throw Object.assign(new Error('unique violation'), { code: '23505' })
+      },
+      clear() {},
+    }
+    setUsedTokenStore(concurrentStore)
+
+    const token = makeRefreshToken()
+    await expect(refresh({ refreshToken: token })).rejects.toThrow()
+  })
+})
+
+describe('clearUsedRefreshTokens', () => {
+  it('allows a previously-used token to be accepted again after reset', async () => {
+    const token = makeRefreshToken()
+
+    // Consume the token
+    await refresh({ refreshToken: token })
+
+    // Reset state
+    clearUsedRefreshTokens()
+
+    // Token should be accepted again (store was wiped)
+    const result = await refresh({ refreshToken: token })
+    expect(result).toHaveProperty('accessToken')
+  })
+})

--- a/tests/unit/services/auth/usedTokenStore.test.ts
+++ b/tests/unit/services/auth/usedTokenStore.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for src/services/auth/usedTokenStore.ts
+ *
+ * Coverage:
+ *   InMemoryUsedTokenStore:
+ *     - has() returns false for unknown JTI
+ *     - has() returns true after mark()
+ *     - mark() is idempotent (no error on duplicate)
+ *     - clear() resets all entries
+ *
+ *   DbUsedTokenStore:
+ *     - has() returns false when DB returns no rows
+ *     - has() returns true when DB returns a row
+ *     - mark() executes INSERT with correct params
+ *     - mark() re-throws on unique violation (23505)
+ *     - mark() re-throws on other DB errors
+ *
+ *   Singleton helpers:
+ *     - getUsedTokenStore() returns the active store
+ *     - setUsedTokenStore() replaces the active store
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  InMemoryUsedTokenStore,
+  DbUsedTokenStore,
+  getUsedTokenStore,
+  setUsedTokenStore,
+} from '../../../../src/services/auth/usedTokenStore.js'
+
+// ---------------------------------------------------------------------------
+// InMemoryUsedTokenStore
+// ---------------------------------------------------------------------------
+
+describe('InMemoryUsedTokenStore', () => {
+  let store: InMemoryUsedTokenStore
+
+  beforeEach(() => {
+    store = new InMemoryUsedTokenStore()
+  })
+
+  it('has() returns false for an unknown JTI', async () => {
+    expect(await store.has('unknown-jti')).toBe(false)
+  })
+
+  it('has() returns true after mark()', async () => {
+    await store.mark('jti-1', 'user-1', new Date(Date.now() + 7 * 86400_000))
+    expect(await store.has('jti-1')).toBe(true)
+  })
+
+  it('mark() is idempotent — no error on duplicate', async () => {
+    const exp = new Date(Date.now() + 7 * 86400_000)
+    await store.mark('jti-dup', 'user-1', exp)
+    await expect(store.mark('jti-dup', 'user-1', exp)).resolves.toBeUndefined()
+  })
+
+  it('clear() removes all entries', async () => {
+    await store.mark('jti-a', 'user-1', new Date())
+    await store.mark('jti-b', 'user-2', new Date())
+    store.clear()
+    expect(await store.has('jti-a')).toBe(false)
+    expect(await store.has('jti-b')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DbUsedTokenStore
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../src/db/client.js', () => ({
+  db: {
+    query: vi.fn(),
+  },
+}))
+
+import { db } from '../../../../src/db/client.js'
+
+describe('DbUsedTokenStore', () => {
+  let store: DbUsedTokenStore
+  const mockQuery = vi.mocked(db.query)
+
+  beforeEach(() => {
+    store = new DbUsedTokenStore()
+    mockQuery.mockReset()
+  })
+
+  describe('has()', () => {
+    it('returns false when DB returns no rows', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
+      expect(await store.has('jti-x')).toBe(false)
+    })
+
+    it('returns true when DB returns a row', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 } as any)
+      expect(await store.has('jti-x')).toBe(true)
+    })
+
+    it('passes the JTI as a query parameter', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as any)
+      await store.has('my-jti')
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('used_refresh_tokens'),
+        ['my-jti']
+      )
+    })
+  })
+
+  describe('mark()', () => {
+    it('executes an INSERT with jti, userId, and expiresAt', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as any)
+      const exp = new Date('2033-01-01T00:00:00Z')
+      await store.mark('jti-y', 'user-42', exp)
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO used_refresh_tokens'),
+        ['jti-y', 'user-42', exp]
+      )
+    })
+
+    it('re-throws on unique violation (23505) — concurrent replay', async () => {
+      const uniqueViolation = Object.assign(new Error('duplicate key'), {
+        code: '23505',
+      })
+      mockQuery.mockRejectedValueOnce(uniqueViolation)
+
+      await expect(
+        store.mark('jti-dup', 'user-1', new Date())
+      ).rejects.toMatchObject({ code: '23505' })
+    })
+
+    it('re-throws on other DB errors', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('connection refused'))
+      await expect(
+        store.mark('jti-z', 'user-1', new Date())
+      ).rejects.toThrow('connection refused')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Singleton helpers
+// ---------------------------------------------------------------------------
+
+describe('getUsedTokenStore / setUsedTokenStore', () => {
+  it('getUsedTokenStore returns the active store', () => {
+    const store = new InMemoryUsedTokenStore()
+    setUsedTokenStore(store)
+    expect(getUsedTokenStore()).toBe(store)
+  })
+
+  it('setUsedTokenStore replaces the active store', () => {
+    const storeA = new InMemoryUsedTokenStore()
+    const storeB = new InMemoryUsedTokenStore()
+    setUsedTokenStore(storeA)
+    setUsedTokenStore(storeB)
+    expect(getUsedTokenStore()).toBe(storeB)
+  })
+})


### PR DESCRIPTION
feat: persist refresh token rotation state

Replace the module-level in-memory Set in refresh.ts with a
UsedTokenStore abstraction backed by PostgreSQL in production.

- Add UsedTokenStore interface with has(), mark(), clear()
- InMemoryUsedTokenStore for test isolation (clearUsedRefreshTokens preserved)
- DbUsedTokenStore persists consumed JTIs with TTL aligned to 7-day refresh lifetime
- refresh.ts extracts jti/exp from verified token, checks store before issuing new pair
- Fails closed if store is unavailable
- Wire DbUsedTokenStore in startServer() at app boot
- Migration: used_refresh_tokens table with PK on jti
- Unit tests for store implementations and refresh service edge cases

Closes #308
