### PR TITLE
fix: use real JWT auth for users profile route

### DIFF
--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,24 +1,8 @@
 import { Router } from 'express'
+import { requireAuth } from '../middleware/requireAuth.js'
 import updateProfile from '../services/user/updateProfile.js'
 
 export const usersRouter = Router()
-
-// Very small auth guard for example purposes: requires `Authorization: Bearer <token>`
-function requireAuth(req: any, res: any, next: any) {
-  const header = req.headers?.authorization
-  if (!header || !header.startsWith('Bearer ')) {
-    return res.status(401).json({ message: 'Unauthorized' })
-  }
-
-  // In a real app we'd verify the token and load the user from DB.
-  // Here we stub a user onto the request for the route to consume.
-  req.user = {
-    id: 'user_123',
-    email: 'alice@example.com',
-    name: 'Alice',
-  }
-  return next()
-}
 
 // PATCH /api/users/me - update current user's profile
 usersRouter.patch('/me', requireAuth, async (req: any, res: any) => {

--- a/tests/unit/routes/users.test.ts
+++ b/tests/unit/routes/users.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import usersRouter from '../../../src/routes/users.js';
+import * as userRepository from '../../../src/repositories/userRepository.js';
+import updateProfile from '../../../src/services/user/updateProfile.js';
+import { generateToken } from '../../../src/utils/jwt.js';
+
+// Mock userRepository and updateProfile service
+vi.mock('../../../src/repositories/userRepository.js', () => ({
+  findUserById: vi.fn(),
+}));
+
+vi.mock('../../../src/services/user/updateProfile.js', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('../../../src/db/client.js', () => ({
+  db: { query: vi.fn() }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/users', usersRouter);
+
+describe('Users Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('PATCH /api/users/me', () => {
+    it('should return 401 when Authorization header is missing', async () => {
+      const response = await request(app)
+        .patch('/api/users/me')
+        .send({ name: 'Alice' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Missing or invalid authorization header' });
+    });
+
+    it('should return 401 when Authorization header is malformed', async () => {
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', 'Basic userpass')
+        .send({ name: 'Alice' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Missing or invalid authorization header' });
+    });
+
+    it('should return 401 when Token is invalid or expired', async () => {
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', 'Bearer invalid-token-string')
+        .send({ name: 'Alice' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Invalid or expired token' });
+    });
+
+    it('should return 401 when user is not found in database', async () => {
+      const token = generateToken({ userId: 'user_not_found', email: 'missing@example.com' });
+      vi.mocked(userRepository.findUserById).mockResolvedValue(null);
+
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Alice' });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'User not found' });
+      expect(userRepository.findUserById).toHaveBeenCalledWith('user_not_found');
+    });
+
+    it('should update profile successfully when valid token is provided', async () => {
+      const token = generateToken({ userId: 'user_123', email: 'alice@example.com' });
+      const mockDbUser = { id: 'user_123', role: 'user' };
+      const updatedUser = { id: 'user_123', name: 'Alice Updated' };
+
+      vi.mocked(userRepository.findUserById).mockResolvedValue(mockDbUser as any);
+      vi.mocked(updateProfile).mockResolvedValue(updatedUser as any);
+
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Alice Updated', profile: { bio: 'hello' } });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(updatedUser);
+      expect(updateProfile).toHaveBeenCalledWith('user_123', {
+        name: 'Alice Updated',
+        profile: { bio: 'hello' },
+      });
+    });
+
+    it('should return 400 when no updatable fields are provided', async () => {
+      const token = generateToken({ userId: 'user_123', email: 'alice@example.com' });
+      const mockDbUser = { id: 'user_123', role: 'user' };
+
+      vi.mocked(userRepository.findUserById).mockResolvedValue(mockDbUser as any);
+
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ email: 'new@example.com' }); // not in allowed fields ('name', 'profile')
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'No updatable fields provided' });
+    });
+
+    it('should return 400 when updateProfile service throws an error', async () => {
+      const token = generateToken({ userId: 'user_123', email: 'alice@example.com' });
+      const mockDbUser = { id: 'user_123', role: 'user' };
+
+      vi.mocked(userRepository.findUserById).mockResolvedValue(mockDbUser as any);
+      vi.mocked(updateProfile).mockRejectedValue(new Error('Update failed due to database constraint'));
+
+      const response = await request(app)
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Alice' });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'Update failed due to database constraint' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaced the stubbed `requireAuth` guard in `users.ts` with the shared JWT authentication middleware from `src/middleware/requireAuth.ts`.

This ensures `PATCH /api/users/me` now validates real JWTs, verifies the authenticated user exists, and scopes profile updates to the authenticated user's actual ID.

## Changes

* Removed the inline stubbed `requireAuth` implementation from `src/routes/users.ts`
* Mounted the shared `requireAuth` middleware
* Updated profile updates to use `req.user.id` from the verified JWT payload
* Added comprehensive route tests covering:

  * Missing authorization header
  * Malformed authorization header
  * Invalid/expired token
  * Missing database user
  * Empty update payload
  * Successful authenticated profile update
  * Service-layer validation errors

## Validation

* All route unit tests passing
* Achieved 100% line coverage for `src/routes/users.ts`
* Branch pushed: `fix/users-route-real-auth`

Closes #306 