### PR TITLE
test: razorpay webhook signature integration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,6 @@ import { config } from "./config/index.js";
 import { createCorsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { requestLogger } from "./middleware/requestLogger.js";
-import { apiVersionMiddleware, versionResponseMiddleware } from "./middleware/apiVersion.js";
 import { analyticsRouter } from "./routes/analytics.js";
 import { attestationsRouter } from "./routes/attestations.js";
 import { authRouter } from "./routes/auth.js";
@@ -17,7 +16,10 @@ import { integrationsShopifyRouter } from "./routes/integrations-shopify.js";
 import { integrationsStripeRouter } from "./routes/integrations-stripe.js";
 import usersRouter from "./routes/users.js";
 import { razorpayWebhookRouter } from "./routes/webhooks-razorpay.js";
-import { StartupReadinessReport } from "./startup/readiness.js";
+import {
+  runStartupDependencyReadinessChecks,
+  StartupReadinessReport,
+} from "./startup/readiness.js";
 
 const apiVersionMiddleware = (req: Request, res: Response, next: NextFunction) => {
   const requestedVersion = req.headers['x-api-version'];
@@ -79,12 +81,13 @@ export function createApp(readinessReport: StartupReadinessReport): Express {
   app.use(apiVersionMiddleware);
   app.use(versionResponseMiddleware);
 
+  app.use("/api/webhooks/razorpay", razorpayWebhookRouter);
+
   // 3. Body Parsing
   app.use(express.json());
   app.use(createCorsMiddleware());
   app.use(requestLogger);
 
-  app.use("/api/webhooks/razorpay", razorpayWebhookRouter);
   app.use("/api/analytics", analyticsRouter);
   app.use("/api/attestations", attestationsRouter);
   app.use("/api/auth", authRouter);

--- a/src/routes/webhooks-razorpay.ts
+++ b/src/routes/webhooks-razorpay.ts
@@ -49,7 +49,7 @@ razorpayWebhookRouter.post('/', (req: Request, res: Response) => {
         }),
       )
 
-      return res.status(error.httpStatus).json({ error: error.message })
+      return res.status(error.httpStatus).json({ error: error.message, code: error.code })
     }
 
     logger.error(

--- a/tests/README.md
+++ b/tests/README.md
@@ -672,6 +672,10 @@ Environment variables used by JWT tests and auth flows:
 - Webhooks: verify provider signatures and reject replays using idempotency keys or event IDs.
 - Integrations: protect OAuth state, never log raw provider tokens, and enforce least-privilege scopes.
 
+## Razorpay Webhook Integration Tests
+
+`tests/integration/razorpay-webhook.test.ts` posts JSON webhook payloads through the mounted Express app and computes the Razorpay HMAC over the same raw UTF-8 bytes sent to the route. Coverage includes valid signed events, tampered payloads, missing signatures, missing `RAZORPAY_WEBHOOK_SECRET`, empty bodies, and replayed event IDs.
+
 ## End-to-End (E2E) Testing Plan
 
 ### Scenarios

--- a/tests/integration/razorpay-webhook.test.ts
+++ b/tests/integration/razorpay-webhook.test.ts
@@ -1,0 +1,319 @@
+import crypto from "node:crypto";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { app } from "../../src/app.js";
+import { resetProcessedRazorpayEvents } from "../../src/services/webhooks/razorpayHandler.js";
+
+const WEBHOOK_PATH = "/api/webhooks/razorpay";
+const WEBHOOK_SECRET = "test_webhook_secret";
+
+function sign(rawBody: Buffer, secret = WEBHOOK_SECRET): string {
+  return crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+}
+
+function rawEventBody(id = "evt_test_razorpay_webhook", event = "payment.captured"): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      id,
+      event,
+      created_at: Math.floor(Date.now() / 1000),
+      payload: {
+        payment: {
+          entity: {
+            id: "pay_test_456",
+            order_id: "order_test_789",
+            status: "captured",
+            amount: 1000,
+            currency: "INR",
+          },
+        },
+      },
+    }),
+  );
+}
+
+function sendRawJson(requestBuilder: request.Test, body: Buffer): request.Test {
+  return requestBuilder
+    .set("Content-Type", "application/json")
+    .send(body.toString("utf8"));
+}
+
+describe("Razorpay webhook integration", () => {
+  const originalSecret = process.env.RAZORPAY_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    resetProcessedRazorpayEvents();
+    process.env.RAZORPAY_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  });
+
+  afterEach(() => {
+    resetProcessedRazorpayEvents();
+    vi.doUnmock("../../src/services/webhooks/razorpayHandler.js");
+
+    if (originalSecret === undefined) {
+      delete process.env.RAZORPAY_WEBHOOK_SECRET;
+    } else {
+      process.env.RAZORPAY_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it("accepts a valid signed raw JSON body and returns the handler result", async () => {
+    const body = rawEventBody("evt_valid_signed_raw_body");
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: "ok",
+      message: "Payment pay_test_456 captured successfully",
+    });
+  });
+
+  it("rejects a tampered raw body signed for different bytes", async () => {
+    const originalBody = rawEventBody("evt_tampered_original_body");
+    const tamperedBody = Buffer.from(
+      originalBody.toString("utf8").replace("pay_test_456", "pay_test_999"),
+    );
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(originalBody))
+      .use((req) => sendRawJson(req, tamperedBody))
+      .expect(401);
+
+    expect(response.body).toMatchObject({
+      code: "invalid_signature",
+      error: "Invalid signature",
+    });
+  });
+
+  it("accepts a valid payment.failed event", async () => {
+    const body = rawEventBody("evt_valid_payment_failed", "payment.failed");
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: "ok",
+      message: "Payment pay_test_456 failed",
+    });
+  });
+
+  it("accepts a valid order.paid event", async () => {
+    const body = rawEventBody("evt_valid_order_paid", "order.paid");
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: "ok",
+      message: "Order order_test_789 marked as paid",
+    });
+  });
+
+  it("ignores signed events outside the handled Razorpay set", async () => {
+    const body = rawEventBody("evt_unhandled_event_type", "refund.created");
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: "ignored",
+      message: "Unhandled event type: refund.created",
+    });
+  });
+
+  it("rejects requests when the webhook secret is not configured", async () => {
+    delete process.env.RAZORPAY_WEBHOOK_SECRET;
+    const body = rawEventBody("evt_secret_not_configured");
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(500);
+
+    expect(response.body).toMatchObject({
+      code: "secret_not_configured",
+      error: "Webhook secret not configured",
+    });
+  });
+
+  it("rejects a missing signature header before processing the body", async () => {
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .use((req) => sendRawJson(req, rawEventBody("evt_missing_signature")))
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      code: "missing_signature",
+      error: "Missing Razorpay signature header",
+    });
+  });
+
+  it("rejects an empty raw body even when the signature header is present", async () => {
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(Buffer.alloc(0)))
+      .use((req) => sendRawJson(req, Buffer.alloc(0)))
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      code: "invalid_payload",
+      error: "Invalid webhook payload",
+    });
+  });
+
+  it("rejects signed malformed JSON after signature verification", async () => {
+    const body = Buffer.from('{"id":"evt_malformed","event":"payment.captured",');
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      code: "invalid_payload",
+      error: "Invalid webhook payload",
+    });
+  });
+
+  it("rejects signed handled events with an invalid schema", async () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        id: "evt_invalid_schema",
+        event: "payment.captured",
+        payload: {},
+      }),
+    );
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      code: "invalid_event",
+      error: "Invalid event structure",
+    });
+  });
+
+  it("rejects signed events with timestamps beyond the future skew", async () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        id: "evt_future_timestamp",
+        event: "payment.captured",
+        created_at: Math.floor((Date.now() + 10 * 60 * 1000) / 1000),
+        payload: {
+          payment: {
+            entity: {
+              id: "pay_test_456",
+              order_id: "order_test_789",
+              status: "captured",
+              amount: 1000,
+              currency: "INR",
+            },
+          },
+        },
+      }),
+    );
+
+    const response = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(400);
+
+    expect(response.body).toMatchObject({
+      code: "invalid_timestamp",
+      error: "Invalid webhook timestamp",
+    });
+  });
+
+  it("handles replayed events idempotently without reprocessing", async () => {
+    const body = rawEventBody("evt_replayed_signed_raw_body");
+    const signature = sign(body);
+
+    await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", signature)
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    const replay = await request(app)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", signature)
+      .use((req) => sendRawJson(req, body))
+      .expect(200);
+
+    expect(replay.body).toEqual({
+      status: "ok",
+      message: "Event evt_replayed_signed_raw_body already processed",
+    });
+  });
+
+  it("returns a generic 500 when verified processing fails unexpectedly", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/services/webhooks/razorpayHandler.js", async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import("../../src/services/webhooks/razorpayHandler.js")>();
+
+      return {
+        ...actual,
+        verifyRazorpaySignature: () => true,
+        parseRazorpayEvent: () => ({
+          id: "evt_unexpected_handler_failure",
+          event: "payment.captured",
+          payload: {
+            payment: {
+              entity: {
+                id: "pay_test_456",
+                order_id: "order_test_789",
+                status: "captured",
+                amount: 1000,
+                currency: "INR",
+              },
+            },
+          },
+        }),
+        handleRazorpayEvent: () => {
+          throw new Error("database unavailable");
+        },
+      };
+    });
+
+    const [{ default: express }, { razorpayWebhookRouter }] = await Promise.all([
+      import("express"),
+      import("../../src/routes/webhooks-razorpay.js"),
+    ]);
+    const isolatedApp = express();
+    const body = rawEventBody("evt_unexpected_handler_failure");
+
+    isolatedApp.use(WEBHOOK_PATH, razorpayWebhookRouter);
+
+    const response = await request(isolatedApp)
+      .post(WEBHOOK_PATH)
+      .set("x-razorpay-signature", sign(body))
+      .use((req) => sendRawJson(req, body))
+      .expect(500);
+
+    expect(response.body).toEqual({ error: "Internal Server Error" });
+
+    vi.doUnmock("../../src/services/webhooks/razorpayHandler.js");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration coverage for Razorpay webhook signature verification and replay handling.

## Changes

- Added Supertest-based Razorpay webhook integration tests using raw JSON bytes for HMAC verification.
- Covered valid signatures, tampered payloads, missing signature header, missing webhook secret, empty body, invalid payloads, future timestamps, ignored events, and replayed event IDs.
- Mounted the Razorpay webhook route before global JSON parsing so production requests preserve the raw body for signature verification.
- Added machine-readable Razorpay webhook rejection codes while preserving existing error messages.
- Documented the Razorpay webhook integration coverage in `tests/README.md`.

## Validation

- `npm test -- tests/integration/razorpay-webhook.test.ts` passed: 13 tests.
- `npm run test:coverage -- tests/integration/razorpay-webhook.test.ts` passed.
  - `src/routes/webhooks-razorpay.ts`: 100% line coverage
  - `src/services/webhooks/razorpayHandler.ts`: 97.72% line coverage

closes #333 