### PR TITLE
feat: paginate and filter attestation list

### DIFF
--- a/src/routes/attestations.ts
+++ b/src/routes/attestations.ts
@@ -8,6 +8,7 @@ import { attestationRepository } from '../repositories/attestation.js';
 import { businessRepository } from '../repositories/business.js';
 import { revokeAttestation } from '../services/attestation/revoke.js';
 import { AppError } from '../types/errors.js';
+import { getPagination, formatPaginatedResponse } from '../utils/pagination.js';
 
 type RouteAttestation = {
   id: string;
@@ -300,19 +301,19 @@ attestationsRouter.get(
       return true;
     });
 
+    const { page, limit, offset } = getPagination({ page: query.page, limit: query.limit });
     const total = filtered.length;
-    const totalPages = Math.max(1, Math.ceil(total / query.limit));
-    const start = (query.page - 1) * query.limit;
-    const items = filtered.slice(start, start + query.limit);
+    const items = filtered.slice(offset, offset + limit);
+    const paginated = formatPaginatedResponse(items, total, page, limit);
 
     res.status(200).json({
       status: 'success',
-      data: items,
+      data: paginated.data,
       pagination: {
-        page: query.page,
-        limit: query.limit,
-        total,
-        totalPages,
+        page: paginated.page,
+        limit: paginated.limit,
+        total: paginated.total,
+        totalPages: paginated.totalPages,
       },
     });
   }),

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -29,7 +29,7 @@ export function formatPaginatedResponse<T>(data: T[], total: number, page: numbe
     total,
     page,
     limit,
-    totalPages: Math.ceil(total / limit) || 0,
+    totalPages: Math.max(1, Math.ceil(total / limit)),
   }
 }
 


### PR DESCRIPTION
## Description

Refactor GET `/api/v1/attestations` to use the shared pagination utilities (`getPagination`, `formatPaginatedResponse`) from `src/utils/pagination.ts` instead of inline pagination logic.

Closes #323

## Changes

- **`src/routes/attestations.ts`**: Import and delegate pagination to `getPagination` (for offset calculation) and `formatPaginatedResponse` (for response shape)
- **`src/utils/pagination.ts`**: Fix `totalPages` to floor at 1 via `Math.max(1, …)` instead of `|| 0` to match existing test expectations (empty result sets should report 1 page)

## Testing

- All 180 attestation-related tests pass
- Updated `formatPaginatedResponse` only used by attestations route (verified via grep)