### PR TITLE
fix: wire attestation submit to soroban service

### DIFF
--- a/src/routes/attestations.ts
+++ b/src/routes/attestations.ts
@@ -7,6 +7,10 @@ import { validateBody, validateQuery } from '../middleware/validate.js';
 import { attestationRepository } from '../repositories/attestation.js';
 import { businessRepository } from '../repositories/business.js';
 import { revokeAttestation } from '../services/attestation/revoke.js';
+import type {
+  SubmitAttestationParams as SorobanSubmitAttestationParams,
+  SubmitAttestationResult as SorobanSubmitAttestationResult,
+} from '../services/soroban/submitAttestation.js';
 import {
   integrateRevenueChecks,
   shouldProceedWithAttestation,
@@ -29,17 +33,9 @@ type RouteAttestation = {
   revokedAt?: string | null;
 };
 
-type SubmitAttestationParams = {
-  business: string;
-  period: string;
-  merkleRoot: string;
-  timestamp: number;
-  version: string;
-};
+type SubmitAttestationParams = Omit<SorobanSubmitAttestationParams, 'sourcePublicKey' | 'signerSecret'>;
 
-type SubmitAttestationResult = {
-  txHash: string;
-};
+type SubmitAttestationResult = SorobanSubmitAttestationResult;
 
 type SorobanServiceError = Error & {
   code?: string;
@@ -102,6 +98,7 @@ const submitBodySchema = z.object({
   merkleRoot: z.string().min(1).max(1024),
   timestamp: z.coerce.number().int('timestamp must be an integer').nonnegative('timestamp must be ≥ 0').optional(),
   version: z.string().min(1).max(50).default('1.0.0'),
+  submit: z.boolean().optional(),
 }).strict();
 
 /**
@@ -246,42 +243,56 @@ async function revokeAttestation(id: string, reason?: string): Promise<RouteAtte
 }
 
 async function submitOnChain(params: SubmitAttestationParams): Promise<SubmitAttestationResult> {
+  const shouldSubmit = params.submit ?? true;
+  const submissionEnabled = process.env.SOROBAN_SUBMIT_ENABLED === 'true';
+
+  if (shouldSubmit && !submissionEnabled) {
+    return { txHash: `pending_${randomUUID()}`, status: 'pending' };
+  }
+
+  const sourcePublicKey = process.env.SOROBAN_SOURCE_PUBLIC_KEY;
+  if (!sourcePublicKey) {
+    throw createHttpError(503, 'SOROBAN_NOT_CONFIGURED', 'Soroban submission is not available right now.');
+  }
+
   const modulePath = '../services/soroban/submitAttestation.js';
   let module: {
-    submitAttestation?: (value: SubmitAttestationParams) => Promise<SubmitAttestationResult>;
+    submitAttestation?: (value: SorobanSubmitAttestationParams) => Promise<SorobanSubmitAttestationResult>;
   };
 
   try {
     module = (await import(modulePath)) as typeof module;
   } catch (_error) {
-    return { txHash: `pending_${randomUUID()}` };
+    return { txHash: `pending_${randomUUID()}`, status: 'pending' };
   }
 
   if (typeof module.submitAttestation !== 'function') {
-    return { txHash: `pending_${randomUUID()}` };
+    return { txHash: `pending_${randomUUID()}`, status: 'pending' };
   }
 
   try {
-    return await module.submitAttestation(params);
+    return await module.submitAttestation({ ...params, sourcePublicKey, submit: shouldSubmit });
   } catch (error) {
     const sorobanError = error as SorobanServiceError;
+    const code = sorobanError?.code;
 
-    if (sorobanError?.code === 'VALIDATION_ERROR') {
-      throw createHttpError(400, sorobanError.code, sorobanError.message);
+    if (code === 'VALIDATION_ERROR') {
+      throw createHttpError(400, code, sorobanError.message);
+    }
+
+    if (code === 'MISSING_SIGNER' || code === 'SIGNER_MISMATCH') {
+      throw createHttpError(503, code, 'Soroban submission is not available right now.');
     }
 
     if (
-      sorobanError?.code === 'MISSING_SIGNER' ||
-      sorobanError?.code === 'SIGNER_MISMATCH'
+      code === 'SUBMIT_FAILED' ||
+      code === 'SOROBAN_NETWORK_ERROR' ||
+      code === 'INVALID_RESPONSE' ||
+      code === 'CONFIRMATION_FAILED' ||
+      code === 'RESULT_VALIDATION_FAILED' ||
+      code === 'RESULT_MISMATCH'
     ) {
-      throw createHttpError(503, sorobanError.code, 'Soroban submission is not available right now.');
-    }
-
-    if (
-      sorobanError?.code === 'SUBMIT_FAILED' ||
-      sorobanError?.code === 'SOROBAN_NETWORK_ERROR'
-    ) {
-      throw createHttpError(502, sorobanError.code, 'Soroban RPC request failed after applying the retry policy.');
+      throw createHttpError(502, code, 'Soroban RPC request failed after applying the retry policy.');
     }
 
     throw error;
@@ -406,7 +417,17 @@ attestationsRouter.post(
       merkleRoot: merkleRoot!,
       timestamp: payload.timestamp ?? Date.now(),
       version: payload.version,
+      submit: payload.submit,
     });
+
+    const submission = {
+      status: onChain.status,
+      txHash: onChain.txHash,
+      ...(onChain.unsignedXdr ? { unsignedXdr: onChain.unsignedXdr } : {}),
+      ...(onChain.ledger !== undefined ? { ledger: onChain.ledger } : {}),
+      ...(onChain.resultMerkleRoot ? { resultMerkleRoot: onChain.resultMerkleRoot } : {}),
+      ...(onChain.resultTimestamp !== undefined ? { resultTimestamp: onChain.resultTimestamp } : {}),
+    };
 
     const now = new Date().toISOString();
     const record: RouteAttestation = {
@@ -428,6 +449,7 @@ attestationsRouter.post(
       status: 'success',
       data: saved,
       txHash: onChain.txHash,
+      submission,
       ...(attestationSummary && {
         attestationSummary: {
           anomaly: attestationSummary.anomaly,

--- a/tests/SETUP.md
+++ b/tests/SETUP.md
@@ -217,6 +217,9 @@ DATABASE_URL=postgresql://postgres:password@localhost:5432/postgres
 SOROBAN_RPC_URL=http://localhost:8000/soroban/rpc
 SOROBAN_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 SOROBAN_CONTRACT_ID=C... (your test contract)
+SOROBAN_SUBMIT_ENABLED=true
+SOROBAN_SOURCE_PUBLIC_KEY=G... (source account public key)
+SOROBAN_SOURCE_SECRET=S... (required for submit=true; omit when using submit=false)
 ```
 
 ### Running E2E Tests

--- a/tests/integration/attestations.test.ts
+++ b/tests/integration/attestations.test.ts
@@ -50,6 +50,9 @@ import {
   PeriodParseError,
 } from '../../src/services/analytics/periods.js';
 
+const ORIGINAL_ENV = { ...process.env };
+const VALID_SOURCE_PUBLIC_KEY = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
 const AUTH = { 'x-user-id': 'user_1' };
 
 const BUSINESS = {
@@ -78,12 +81,15 @@ const VALID_SUBMIT = {
 
 describe('Attestations HTTP integration', () => {
   beforeEach(() => {
+    process.env.SOROBAN_SUBMIT_ENABLED = 'true';
+    process.env.SOROBAN_SOURCE_PUBLIC_KEY = VALID_SOURCE_PUBLIC_KEY;
     submitAttestationMock.mockClear();
-    submitAttestationMock.mockResolvedValue({ txHash: 'tx_default_mock' });
+    submitAttestationMock.mockResolvedValue({ txHash: 'tx_default_mock', status: 'pending' });
     vi.spyOn(businessRepository, 'getByUserId').mockResolvedValue(BUSINESS);
   });
 
   afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
     vi.restoreAllMocks();
   });
 
@@ -542,6 +548,56 @@ describe('Attestations HTTP integration', () => {
       expect(second.status).toBe(201);
       expect(second.body).toEqual(first.body);
       expect(submitAttestationMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /api/attestations — submission response', () => {
+    it('includes submission status and tx hash', async () => {
+      const res = await request(app)
+        .post('/api/attestations')
+        .set(AUTH)
+        .set('Idempotency-Key', iKey('submission-status'))
+        .send(VALID_SUBMIT);
+      expect(res.status).toBe(201);
+      expect(res.body.submission).toMatchObject({
+        status: 'pending',
+        txHash: 'tx_default_mock',
+      });
+    });
+
+    it('returns unsigned XDR when submit=false', async () => {
+      submitAttestationMock.mockResolvedValueOnce({
+        txHash: 'tx_unsigned_mock',
+        status: 'unsigned',
+        unsignedXdr: 'AAAA_fake_xdr',
+      });
+
+      const res = await request(app)
+        .post('/api/attestations')
+        .set(AUTH)
+        .set('Idempotency-Key', iKey('unsigned'))
+        .send({ ...VALID_SUBMIT, submit: false });
+      expect(res.status).toBe(201);
+      expect(res.body.submission).toMatchObject({
+        status: 'unsigned',
+        txHash: 'tx_unsigned_mock',
+        unsignedXdr: 'AAAA_fake_xdr',
+      });
+    });
+
+    it('skips Soroban submission when SOROBAN_SUBMIT_ENABLED is not true', async () => {
+      process.env.SOROBAN_SUBMIT_ENABLED = 'false';
+      submitAttestationMock.mockClear();
+
+      const res = await request(app)
+        .post('/api/attestations')
+        .set(AUTH)
+        .set('Idempotency-Key', iKey('flag-off'))
+        .send(VALID_SUBMIT);
+      expect(res.status).toBe(201);
+      expect(submitAttestationMock).not.toHaveBeenCalled();
+      expect(res.body.submission.status).toBe('pending');
+      expect(res.body.txHash).toMatch(/^pending_/);
     });
   });
 


### PR DESCRIPTION
## Closes #310

## Summary
Gates Soroban submission behind `SOROBAN_SUBMIT_ENABLED` and returns submission metadata (status, tx hash, unsigned XDR).

## Root Cause
The route used a stub and never invoked the real Soroban submission service, so clients could not see submission status or unsigned outputs.

## Changes
- Route now calls the Soroban service when enabled, passes `submit: false`, and maps Soroban errors consistently
- Integration tests cover status surfacing, unsigned path, and flag-off stub behavior
- E2E setup docs updated with the new Soroban submission env vars