### PR TITLE
fix: enforce one business per user in db

### DIFF
--- a/src/db/migrations/20260529_001_add_businesses_user_id_unique.sql
+++ b/src/db/migrations/20260529_001_add_businesses_user_id_unique.sql
@@ -1,0 +1,5 @@
+-- Migration: 20260529_001_add_businesses_user_id_unique
+-- Enforce one-business-per-user at the database layer.
+
+CREATE UNIQUE INDEX IF NOT EXISTS businesses_user_id_unique_idx
+  ON businesses (user_id);

--- a/src/services/business/create.ts
+++ b/src/services/business/create.ts
@@ -31,11 +31,28 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { businessRepository } from '../../repositories/business.js';
+import { AppError } from '../../types/errors.js';
 import {
   parseCreateBusinessInput,
   CreateBusinessInput,
 } from './schemas.js';
 import { formatForStorage } from './normalize.js';
+
+const BUSINESS_USER_UNIQUE_CONSTRAINT = 'businesses_user_id_unique_idx';
+
+type PostgresError = Error & { code?: string; constraint?: string };
+
+function isBusinessOwnerUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const pgError = error as PostgresError;
+  return (
+    pgError.code === '23505' &&
+    pgError.constraint === BUSINESS_USER_UNIQUE_CONSTRAINT
+  );
+}
 
 /**
  * Create Business Handler
@@ -157,6 +174,14 @@ export async function createBusiness(req: Request, res: Response) {
     // @dev Return created business with 201 status
     return res.status(201).json(business);
   } catch (error) {
+    if (isBusinessOwnerUniqueViolation(error)) {
+      throw new AppError(
+        'A business already exists for this user',
+        409,
+        'BUSINESS_ALREADY_EXISTS',
+      );
+    }
+
     // @dev Structured log: emit a JSON-serialisable object so log aggregators
     //      (e.g. Datadog, Cloud Logging) can index fields individually.
     console.error(JSON.stringify({

--- a/tests/unit/services/business/create.test.ts
+++ b/tests/unit/services/business/create.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createBusiness } from '../../../../src/services/business/create.js';
+import { businessRepository } from '../../../../src/repositories/business.js';
+import { AppError } from '../../../../src/types/errors.js';
+
+const VALID_USER = { id: 'user-1', email: 'user@example.com' };
+const EXISTING_BUSINESS = {
+  id: 'biz-1',
+  userId: 'user-1',
+  name: 'Acme',
+  email: 'user@example.com',
+  industry: null,
+  description: null,
+  website: null,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    user: VALID_USER,
+    body: { name: 'Acme Corp' },
+    ...overrides,
+  } as Request;
+}
+
+function makeRes(): { res: Response; status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as Response;
+  return { res, status, json };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createBusiness', () => {
+  it('returns 409 when a business already exists (fast path)', async () => {
+    vi.spyOn(businessRepository, 'getByUserId').mockResolvedValue(EXISTING_BUSINESS as any);
+    const createSpy = vi.spyOn(businessRepository, 'create');
+
+    const { res, status, json } = makeRes();
+    await createBusiness(makeReq(), res);
+
+    expect(status).toHaveBeenCalledWith(409);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'BUSINESS_ALREADY_EXISTS' }),
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws AppError on unique constraint violation', async () => {
+    vi.spyOn(businessRepository, 'getByUserId').mockResolvedValue(null);
+    vi.spyOn(businessRepository, 'create').mockRejectedValue(
+      Object.assign(new Error('duplicate key'), {
+        code: '23505',
+        constraint: 'businesses_user_id_unique_idx',
+      }),
+    );
+
+    const err = await createBusiness(makeReq(), makeRes().res).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.status).toBe(409);
+    expect(err.code).toBe('BUSINESS_ALREADY_EXISTS');
+  });
+
+  it('returns 500 for other unique violations', async () => {
+    vi.spyOn(businessRepository, 'getByUserId').mockResolvedValue(null);
+    vi.spyOn(businessRepository, 'create').mockRejectedValue(
+      Object.assign(new Error('duplicate key'), {
+        code: '23505',
+        constraint: 'other_unique_idx',
+      }),
+    );
+
+    const { res, status, json } = makeRes();
+    await createBusiness(makeReq(), res);
+
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'INTERNAL_ERROR' }),
+    );
+  });
+});


### PR DESCRIPTION
## Closes #322

## Summary
Enforces one-business-per-user with a DB unique index and maps the constraint violation to a 409 conflict error in the create handler.

## Root Cause
Application-level checks were race-prone and the database had no uniqueness enforcement on `businesses.user_id`.

## Changes
- Added unique index migration on `businesses.user_id`
- Detected the specific constraint violation and raised a 409 `AppError`
- Added unit coverage for the fast-path and constraint-matching scenarios