### PR TITLE
fix: log admin user mutation outcomes

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -9,6 +9,19 @@ import { db } from '../db/client.js'
 
 const adminRouter = Router()
 
+const SENSITIVE_UPDATE_FIELDS = new Set(['passwordHash', 'resetToken', 'resetTokenExpiry'])
+
+function normalizeUpdates(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return {}
+  }
+  return payload as Record<string, unknown>
+}
+
+function getAuditUpdateFields(updates: Record<string, unknown>): string[] {
+  return Object.keys(updates).filter(field => !SENSITIVE_UPDATE_FIELDS.has(field))
+}
+
 // All routes here require authentication
 adminRouter.use(requireAuth)
 
@@ -65,27 +78,52 @@ adminRouter.patch(
   '/users/:id',
   requirePermissions(IntegrationPermission.ADMIN_MANAGE_USERS),
   async (req, res) => {
+    const { id } = req.params
+    const updates = normalizeUpdates(req.body)
+    const updateFields = getAuditUpdateFields(updates)
+
     try {
-      const { id } = req.params
-      const updates = req.body
-      
       const user = await findUserById(id)
       if (!user) {
+        await createAuditLog({
+          userId: req.user!.id,
+          action: 'UPDATE_USER',
+          resource: 'user',
+          resourceId: id,
+          metadata: { outcome: 'not_found', updateFields },
+        })
         return res.status(404).json({ error: 'Not Found', message: 'User not found' })
       }
       
       const updatedUser = await updateUser(id, updates)
+      if (!updatedUser) {
+        await createAuditLog({
+          userId: req.user!.id,
+          action: 'UPDATE_USER',
+          resource: 'user',
+          resourceId: id,
+          metadata: { outcome: 'not_found', updateFields },
+        })
+        return res.status(404).json({ error: 'Not Found', message: 'User not found' })
+      }
       
       await createAuditLog({
         userId: req.user!.id,
         action: 'UPDATE_USER',
         resource: 'user',
         resourceId: id,
-        metadata: { updates }
+        metadata: { outcome: 'success', updateFields }
       })
       
       res.json(updatedUser)
     } catch (error: any) {
+      await createAuditLog({
+        userId: req.user?.id ?? 'unknown',
+        action: 'UPDATE_USER',
+        resource: 'user',
+        resourceId: id,
+        metadata: { outcome: 'error' },
+      })
       res.status(500).json({ error: 'Internal Server Error', message: error.message })
     }
   }
@@ -99,26 +137,50 @@ adminRouter.delete(
   '/users/:id',
   requirePermissions(IntegrationPermission.ADMIN_MANAGE_USERS),
   async (req, res) => {
+    const { id } = req.params
+
     try {
-      const { id } = req.params
-      
       const user = await findUserById(id)
       if (!user) {
+        await createAuditLog({
+          userId: req.user!.id,
+          action: 'DELETE_USER',
+          resource: 'user',
+          resourceId: id,
+          metadata: { outcome: 'not_found' },
+        })
         return res.status(404).json({ error: 'Not Found', message: 'User not found' })
       }
       
-      await deleteUser(id)
+      const deleted = await deleteUser(id)
+      if (!deleted) {
+        await createAuditLog({
+          userId: req.user!.id,
+          action: 'DELETE_USER',
+          resource: 'user',
+          resourceId: id,
+          metadata: { outcome: 'not_found' },
+        })
+        return res.status(404).json({ error: 'Not Found', message: 'User not found' })
+      }
       
       await createAuditLog({
         userId: req.user!.id,
         action: 'DELETE_USER',
         resource: 'user',
         resourceId: id,
-        metadata: { deletedUserEmail: user.email }
+        metadata: { outcome: 'success' }
       })
       
       res.sendStatus(204)
     } catch (error: any) {
+      await createAuditLog({
+        userId: req.user?.id ?? 'unknown',
+        action: 'DELETE_USER',
+        resource: 'user',
+        resourceId: id,
+        metadata: { outcome: 'error' },
+      })
       res.status(500).json({ error: 'Internal Server Error', message: error.message })
     }
   }

--- a/tests/unit/routes/admin.test.ts
+++ b/tests/unit/routes/admin.test.ts
@@ -18,7 +18,8 @@ vi.mock('../../../src/db/client.js', () => ({
 // Mock auth and permission middleware
 vi.mock('../../../src/middleware/requireAuth.js', () => ({
   requireAuth: (req: any, res: any, next: any) => {
-    req.user = { id: 'admin_123', userId: 'admin_123', email: 'admin@test.com', role: 'admin' };
+    const role = (req.headers['x-user-role'] as string) || 'admin';
+    req.user = { id: 'admin_123', userId: 'admin_123', email: 'admin@test.com', role };
     next();
   }
 }));
@@ -95,13 +96,36 @@ describe('Admin Routes', () => {
 
       const response = await request(app)
         .patch('/api/v1/admin/users/user_1')
-        .send({ role: 'admin' });
+        .send({ role: 'admin', passwordHash: 'secret' });
 
       expect(response.status).toBe(200);
       expect(response.body.role).toBe('admin');
       expect(auditLogRepository.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
         action: 'UPDATE_USER',
-        resourceId: 'user_1'
+        resourceId: 'user_1',
+        metadata: expect.objectContaining({
+          outcome: 'success',
+          updateFields: ['role'],
+        }),
+      }));
+    });
+
+    it('should allow admin to update self and create audit log', async () => {
+      const mockUser = { id: 'admin_123', email: 'admin@test.com', role: 'admin' };
+      vi.mocked(userRepository.findUserById).mockResolvedValue(mockUser as any);
+      vi.mocked(userRepository.updateUser).mockResolvedValue({ ...mockUser, role: 'admin' } as any);
+
+      const response = await request(app)
+        .patch('/api/v1/admin/users/admin_123')
+        .send({ role: 'admin' });
+
+      expect(response.status).toBe(200);
+      expect(auditLogRepository.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'UPDATE_USER',
+        resourceId: 'admin_123',
+        metadata: expect.objectContaining({
+          outcome: 'success',
+        }),
       }));
     });
 
@@ -113,6 +137,23 @@ describe('Admin Routes', () => {
         .send({ role: 'admin' });
 
       expect(response.status).toBe(404);
+      expect(auditLogRepository.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'UPDATE_USER',
+        resourceId: 'invalid',
+        metadata: expect.objectContaining({
+          outcome: 'not_found',
+        }),
+      }));
+    });
+
+    it('should return 403 when permissions are denied', async () => {
+      const response = await request(app)
+        .patch('/api/v1/admin/users/user_1')
+        .set('x-user-role', 'user')
+        .send({ role: 'admin' });
+
+      expect(response.status).toBe(403);
+      expect(auditLogRepository.createAuditLog).not.toHaveBeenCalled();
     });
   });
 
@@ -127,7 +168,25 @@ describe('Admin Routes', () => {
       expect(response.status).toBe(204);
       expect(auditLogRepository.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
         action: 'DELETE_USER',
-        resourceId: 'user_1'
+        resourceId: 'user_1',
+        metadata: expect.objectContaining({
+          outcome: 'success',
+        }),
+      }));
+    });
+
+    it('should return 404 if user not found', async () => {
+      vi.mocked(userRepository.findUserById).mockResolvedValue(null);
+
+      const response = await request(app).delete('/api/v1/admin/users/missing');
+
+      expect(response.status).toBe(404);
+      expect(auditLogRepository.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'DELETE_USER',
+        resourceId: 'missing',
+        metadata: expect.objectContaining({
+          outcome: 'not_found',
+        }),
       }));
     });
   });


### PR DESCRIPTION
## Closes #324

## Summary
Adds structured audit logs for admin user update/delete actions with sanitized fields and explicit outcomes.

## Root Cause
Admin mutation handlers only logged success and included raw update payloads, leaving failures untracked and sensitive fields exposed in logs.

## Changes
- Added outcome-aware audit logging for success, not-found, and error paths
- Sanitized update fields in audit log output
- Expanded admin route tests for key edge cases