### PR TITLE
feat: add rollback support to migrator closes #377

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "migrate": "tsx src/db/migrate.ts",
+    "migrate:rollback": "tsx src/db/migrate.ts rollback",
     "docs:routes": "tsx scripts/generate-routes.ts",
     "docs:openapi": "tsx scripts/generate-openapi.ts"
   },

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,72 +1,188 @@
 /**
- * Migration runner: runs pending SQL migrations from src/db/migrations/.
+ * Migration runner: applies pending SQL migrations and supports rollback.
  * Tracks applied migrations in schema_migrations so each runs once.
  *
- * Usage: npm run migrate (reads DATABASE_URL from .env or env)
+ * Usage:
+ *   npm run migrate              – apply all pending migrations
+ *   npm run migrate:rollback     – roll back the last 1 migration
+ *   npm run migrate:rollback 3   – roll back the last 3 migrations
+ *
+ * File conventions (both supported):
+ *   Legacy:  001_foo.sql          → up-only, no rollback available
+ *   Paired:  001_foo.up.sql  +  001_foo.down.sql  → supports rollback
  */
+
 import pg from 'pg'
-import { readdir, readFile } from 'node:fs/promises'
+import { readdir, readFile, access } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+export const MIGRATIONS_DIR = join(__dirname, 'migrations')
 
-const MIGRATIONS_DIR = join(__dirname, 'migrations')
+// ─── helpers ────────────────────────────────────────────────────────────────
 
-async function runMigrations(): Promise<void> {
+/** Returns all unique migration versions, sorted ascending. */
+export async function discoverMigrations(dir: string = MIGRATIONS_DIR): Promise<string[]> {
+  const files = await readdir(dir)
+  const versions = new Set<string>()
+
+  for (const f of files) {
+    if (f.endsWith('.up.sql')) {
+      versions.add(f.replace(/\.up\.sql$/, ''))
+    } else if (f.endsWith('.sql') && !f.endsWith('.down.sql')) {
+      // legacy up-only file
+      versions.add(f.replace(/\.sql$/, ''))
+    }
+  }
+
+  return [...versions].sort()
+}
+
+/** Reads the UP sql for a version. Prefers .up.sql, falls back to legacy .sql */
+export async function getUpSql(version: string, dir: string = MIGRATIONS_DIR): Promise<string> {
+  const upPath = join(dir, `${version}.up.sql`)
+  try {
+    await access(upPath)
+    return readFile(upPath, 'utf-8')
+  } catch {
+    // try legacy
+    const legacyPath = join(dir, `${version}.sql`)
+    try {
+      await access(legacyPath)
+      return readFile(legacyPath, 'utf-8')
+    } catch {
+      throw new Error(`No up-migration file found for version: ${version}`)
+    }
+  }
+}
+
+/**
+ * Reads the DOWN sql for a version.
+ * Throws a clear error if the .down.sql file is missing — rollback is refused.
+ */
+export async function getDownSql(version: string, dir: string = MIGRATIONS_DIR): Promise<string> {
+  const downPath = join(dir, `${version}.down.sql`)
+  try {
+    await access(downPath)
+    return readFile(downPath, 'utf-8')
+  } catch {
+    throw new Error(
+      `Cannot roll back "${version}": missing ${version}.down.sql — ` +
+      `create this file to enable rollback for this migration.`
+    )
+  }
+}
+
+// ─── core logic ─────────────────────────────────────────────────────────────
+
+export async function runMigrations(client: pg.Client, dir: string = MIGRATIONS_DIR): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+
+  const versions = await discoverMigrations(dir)
+  const applied = new Set(
+    (await client.query('SELECT version FROM schema_migrations'))
+      .rows.map((r: { version: string }) => r.version)
+  )
+
+  const pending = versions.filter((v) => !applied.has(v))
+
+  if (pending.length === 0) {
+    console.log('No pending migrations.')
+    return
+  }
+
+  for (const version of pending) {
+    const sql = await getUpSql(version, dir)
+    await client.query('BEGIN')
+    try {
+      await client.query(sql)
+      await client.query('INSERT INTO schema_migrations (version) VALUES ($1)', [version])
+      await client.query('COMMIT')
+      console.log(`Applied: ${version}`)
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw new Error(`Migration failed for "${version}": ${(err as Error).message}`)
+    }
+  }
+}
+
+export async function runRollback(
+  client: pg.Client,
+  steps: number = 1,
+  dir: string = MIGRATIONS_DIR
+): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `)
+
+  const { rows } = await client.query<{ version: string }>(
+    'SELECT version FROM schema_migrations ORDER BY version DESC LIMIT $1',
+    [steps]
+  )
+
+  if (rows.length === 0) {
+    console.log('Nothing to roll back.')
+    return
+  }
+
+  // Validate ALL .down.sql files exist BEFORE touching the database
+  for (const { version } of rows) {
+    await getDownSql(version, dir) // throws immediately if missing
+  }
+
+  for (const { version } of rows) {
+    const sql = await getDownSql(version, dir)
+    await client.query('BEGIN')
+    try {
+      await client.query(sql)
+      await client.query('DELETE FROM schema_migrations WHERE version = $1', [version])
+      await client.query('COMMIT')
+      console.log(`Rolled back: ${version}`)
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw new Error(`Rollback failed for "${version}": ${(err as Error).message}`)
+    }
+  }
+}
+
+// ─── CLI entry point ─────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
   const connectionString = process.env.DATABASE_URL
   if (!connectionString) {
-    console.error('DATABASE_URL is required to run migrations.')
+    console.error('DATABASE_URL is required.')
     process.exit(1)
   }
+
+  const command = process.argv[2]   // 'rollback' or undefined
+  const steps   = parseInt(process.argv[3] ?? '1', 10)
 
   const client = new pg.Client({ connectionString })
   try {
     await client.connect()
-
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS schema_migrations (
-        version TEXT PRIMARY KEY,
-        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
-      )
-    `)
-
-    const files = (await readdir(MIGRATIONS_DIR))
-      .filter((f) => f.endsWith('.sql'))
-      .sort()
-    const applied = new Set(
-      (await client.query('SELECT version FROM schema_migrations'))
-        .rows
-        .map((r: { version: string }) => r.version)
-    )
-
-    for (const file of files) {
-      const version = file.replace(/\.sql$/, '')
-      if (applied.has(version)) {
-        console.log(`Skip (already applied): ${file}`)
-        continue
-      }
-      const sql = await readFile(join(MIGRATIONS_DIR, file), 'utf-8')
-      await client.query('BEGIN')
-      try {
-        await client.query(sql)
-        await client.query(
-          'INSERT INTO schema_migrations (version) VALUES ($1)',
-          [version]
-        )
-        await client.query('COMMIT')
-        console.log(`Applied: ${file}`)
-      } catch (err) {
-        await client.query('ROLLBACK')
-        throw err
-      }
+    if (command === 'rollback') {
+      await runRollback(client, steps)
+    } else {
+      await runMigrations(client)
     }
   } finally {
     await client.end()
   }
 }
 
-runMigrations().catch((err) => {
-  console.error('Migration failed:', err)
-  process.exit(1)
-})
+// Only run when executed directly (not when imported in tests)
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((err) => {
+    console.error('Fatal:', err.message)
+    process.exit(1)
+  })
+}

--- a/src/db/migrations/001_create_users_table.down.sql
+++ b/src/db/migrations/001_create_users_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/src/db/migrations/002_create_revenue_snapshots_table.down.sql
+++ b/src/db/migrations/002_create_revenue_snapshots_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS revenue_snapshots;

--- a/src/db/migrations/20260225_001_create_attestations_table.down.sql
+++ b/src/db/migrations/20260225_001_create_attestations_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS attestations;

--- a/src/db/migrations/20260527_001_create_used_refresh_tokens_table.down.sql
+++ b/src/db/migrations/20260527_001_create_used_refresh_tokens_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS used_refresh_tokens;

--- a/src/db/migrations/20260529_001_add_businesses_user_id_unique.down.sql
+++ b/src/db/migrations/20260529_001_add_businesses_user_id_unique.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE businesses DROP CONSTRAINT IF EXISTS businesses_user_id_key;

--- a/tests/db/migrate.test.ts
+++ b/tests/db/migrate.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for src/db/migrate.ts
+ * Covers: discoverMigrations, getUpSql, getDownSql, runMigrations, runRollback
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mock node:fs/promises before importing the module ───────────────────────
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  access:  vi.fn(),
+}))
+
+import * as fsp from 'node:fs/promises'
+import {
+  discoverMigrations,
+  getUpSql,
+  getDownSql,
+  runMigrations,
+  runRollback,
+  MIGRATIONS_DIR,
+} from '../../src/db/migrate'
+
+const mockReaddir = fsp.readdir  as ReturnType<typeof vi.fn>
+const mockReadFile = fsp.readFile as ReturnType<typeof vi.fn>
+const mockAccess  = fsp.access   as ReturnType<typeof vi.fn>
+
+// ─── Mock pg client factory ──────────────────────────────────────────────────
+function makeMockClient(defaultRows: { version: string }[] = []) {
+  const calls: string[] = []
+
+  const query = vi.fn(async (sql: string) => {
+    calls.push(sql.trim())
+    if (sql.includes('SELECT version FROM schema_migrations')) {
+      return { rows: defaultRows }
+    }
+    return { rows: [] }
+  })
+
+  const client = { query, calls }
+  return client
+}
+
+// helper: override query AND keep recording calls
+function withQueryImpl(
+  client: ReturnType<typeof makeMockClient>,
+  impl: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+) {
+  client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    client.calls.push(sql.trim())
+    return impl(sql, params)
+  })
+}
+
+// ─── discoverMigrations ───────────────────────────────────────────────────────
+describe('discoverMigrations', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('discovers legacy .sql files', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql', '002_posts.sql'])
+    expect(await discoverMigrations('/fake')).toEqual(['001_users', '002_posts'])
+  })
+
+  it('discovers paired .up.sql files and ignores .down.sql', async () => {
+    mockReaddir.mockResolvedValue(['001_users.up.sql', '001_users.down.sql'])
+    expect(await discoverMigrations('/fake')).toEqual(['001_users'])
+  })
+
+  it('deduplicates when both legacy and .up.sql somehow coexist', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql', '001_users.up.sql'])
+    expect(await discoverMigrations('/fake')).toEqual(['001_users'])
+  })
+
+  it('returns results sorted ascending', async () => {
+    mockReaddir.mockResolvedValue(['003_c.sql', '001_a.sql', '002_b.sql'])
+    expect(await discoverMigrations('/fake')).toEqual(['001_a', '002_b', '003_c'])
+  })
+
+  it('returns empty array when no migration files exist', async () => {
+    mockReaddir.mockResolvedValue(['README.md', 'seed.js'])
+    expect(await discoverMigrations('/fake')).toEqual([])
+  })
+})
+
+// ─── getUpSql ────────────────────────────────────────────────────────────────
+describe('getUpSql', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('reads .up.sql when it exists', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('CREATE TABLE foo();')
+    const sql = await getUpSql('001_foo', '/fake')
+    expect(sql).toBe('CREATE TABLE foo();')
+    expect(mockAccess).toHaveBeenCalledWith(expect.stringContaining('001_foo.up.sql'))
+  })
+
+  it('falls back to legacy .sql when .up.sql is absent', async () => {
+    mockAccess
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce(undefined)
+    mockReadFile.mockResolvedValue('CREATE TABLE bar();')
+    const sql = await getUpSql('001_bar', '/fake')
+    expect(sql).toBe('CREATE TABLE bar();')
+    expect(mockAccess).toHaveBeenCalledWith(expect.stringContaining('001_bar.sql'))
+  })
+
+  it('throws when neither .up.sql nor legacy .sql exists', async () => {
+    mockAccess.mockRejectedValue(new Error('not found'))
+    await expect(getUpSql('999_missing', '/fake')).rejects.toThrow(
+      'No up-migration file found for version: 999_missing'
+    )
+  })
+})
+
+// ─── getDownSql ──────────────────────────────────────────────────────────────
+describe('getDownSql', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('reads .down.sql when it exists', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE foo;')
+    expect(await getDownSql('001_foo', '/fake')).toBe('DROP TABLE foo;')
+  })
+
+  it('throws a clear error when .down.sql is missing', async () => {
+    mockAccess.mockRejectedValue(new Error('not found'))
+    await expect(getDownSql('001_foo', '/fake')).rejects.toThrow(
+      'Cannot roll back "001_foo"'
+    )
+  })
+
+  it('error message includes the missing filename', async () => {
+    mockAccess.mockRejectedValue(new Error('not found'))
+    await expect(getDownSql('001_foo', '/fake')).rejects.toThrow('001_foo.down.sql')
+  })
+})
+
+// ─── runMigrations ───────────────────────────────────────────────────────────
+describe('runMigrations', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('applies pending migrations in order', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql', '002_posts.sql'])
+    mockAccess
+      .mockRejectedValueOnce(new Error()) // 001 .up.sql missing
+      .mockResolvedValueOnce(undefined)   // 001 legacy .sql exists
+      .mockRejectedValueOnce(new Error()) // 002 .up.sql missing
+      .mockResolvedValueOnce(undefined)   // 002 legacy .sql exists
+    mockReadFile.mockResolvedValue('CREATE TABLE x();')
+
+    const client = makeMockClient([])
+    await runMigrations(client as never, '/fake')
+
+    expect(client.calls).toContain('BEGIN')
+    expect(client.calls).toContain('COMMIT')
+    expect(client.calls.filter((q) => q === 'COMMIT')).toHaveLength(2)
+  })
+
+  it('skips already-applied migrations', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql'])
+    const client = makeMockClient([{ version: '001_users' }])
+    await runMigrations(client as never, '/fake')
+    expect(client.calls).not.toContain('BEGIN')
+  })
+
+  it('prints "No pending migrations" when all are applied', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql'])
+    const client = makeMockClient([{ version: '001_users' }])
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await runMigrations(client as never, '/fake')
+    expect(spy).toHaveBeenCalledWith('No pending migrations.')
+    spy.mockRestore()
+  })
+
+  it('rolls back transaction and throws on SQL failure', async () => {
+    mockReaddir.mockResolvedValue(['001_users.sql'])
+    mockAccess
+      .mockRejectedValueOnce(new Error()) // .up.sql missing
+      .mockResolvedValueOnce(undefined)   // legacy .sql exists
+    mockReadFile.mockResolvedValue('CREATE TABLE x();')
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      if (sql.trim() === 'CREATE TABLE x();') throw new Error('Simulated DB failure')
+      return { rows: [] }
+    })
+
+    await expect(runMigrations(client as never, '/fake')).rejects.toThrow('Simulated DB failure')
+    expect(client.calls).toContain('ROLLBACK')
+  })
+})
+
+// ─── runRollback ─────────────────────────────────────────────────────────────
+describe('runRollback', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('rolls back the most recent migration', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE users;')
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '001_users' }] }
+      }
+      return { rows: [] }
+    })
+
+    await runRollback(client as never, 1, '/fake')
+
+    expect(client.calls).toContain('BEGIN')
+    expect(client.calls).toContain('COMMIT')
+    expect(client.calls).toContain('DELETE FROM schema_migrations WHERE version = $1')
+  })
+
+  it('does nothing when schema_migrations is empty', async () => {
+    const client = makeMockClient([])
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await runRollback(client as never, 1, '/fake')
+    expect(spy).toHaveBeenCalledWith('Nothing to roll back.')
+    spy.mockRestore()
+  })
+
+  it('refuses rollback when .down.sql is missing', async () => {
+    mockAccess.mockRejectedValue(new Error('not found'))
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '001_users' }] }
+      }
+      return { rows: [] }
+    })
+    await expect(runRollback(client as never, 1, '/fake')).rejects.toThrow('Cannot roll back')
+    expect(client.calls).not.toContain('BEGIN')
+  })
+
+  it('supports multi-step rollback', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE x;')
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '002_b' }, { version: '001_a' }] }
+      }
+      return { rows: [] }
+    })
+
+    await runRollback(client as never, 2, '/fake')
+    expect(client.calls.filter((s) => s === 'COMMIT')).toHaveLength(2)
+  })
+
+  it('rolls back transaction and throws on mid-rollback DB failure', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE users;')
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '001_users' }] }
+      }
+      if (sql.trim() === 'DROP TABLE users;') throw new Error('Simulated DB failure')
+      return { rows: [] }
+    })
+
+    await expect(runRollback(client as never, 1, '/fake')).rejects.toThrow('Rollback failed')
+    expect(client.calls).toContain('ROLLBACK')
+  })
+
+  it('validates ALL down files exist before touching the DB', async () => {
+    mockAccess
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('missing'))
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '002_b' }, { version: '001_a' }] }
+      }
+      return { rows: [] }
+    })
+
+    await expect(runRollback(client as never, 2, '/fake')).rejects.toThrow('Cannot roll back')
+    expect(client.calls).not.toContain('BEGIN')
+  })
+})


### PR DESCRIPTION
Closes #377

## Summary
Adds `.down.sql` rollback support to `src/db/migrate.ts` and a `migrate:rollback` script.

## Changes
- `src/db/migrate.ts` — refactored to support paired `.up.sql`/`.down.sql` files while keeping legacy `.sql` files working. Added `runRollback()` which validates all down files exist before touching the DB, then reverses migrations inside transactions.
- `package.json` — added `migrate:rollback` script
- `src/db/migrations/*.down.sql` — added down files for all 5 existing migrations
- `tests/db/migrate.test.ts` — 21 tests covering all functions and edge cases

## Test output
21 passed (21) — 100% of migrate module tests passing