### PR TITLE
feat: Add mTLS support for internal service-to-service communication

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
 import express, { type Express } from "express";
 import type { Server } from "node:http";
+import type { Server as HttpsServer } from "node:https";
 import type { Request, Response, NextFunction } from "express";
+import fs from "node:fs/promises";
 import { config } from "./config/index.js";
 import { createCorsMiddleware } from "./middleware/cors.js";
 import { errorHandler } from "./middleware/errorHandler.js";
@@ -9,6 +11,7 @@ import {
   apiVersionMiddleware,
   versionResponseMiddleware,
 } from "./middleware/apiVersion.js";
+import { mtlsMiddleware } from "./middleware/mtls.js";
 import { metricsRegistry } from "./metrics.js";
 import { analyticsRouter } from "./routes/analytics.js";
 import { attestationsRouter } from "./routes/attestations.js";
@@ -60,6 +63,7 @@ export function createApp(readinessReport: StartupReadinessReport): Express {
 
   app.use(requestLogger);
   app.use(securityHeadersMiddleware);
+  app.use(mtlsMiddleware);
   app.use(apiVersionMiddleware);
   app.use(versionResponseMiddleware);
 
@@ -106,9 +110,9 @@ export const app = createApp({ ready: true, checks: [] });
  * Runs readiness checks before starting the listener.
  * 
  * @param port - Port to listen on.
- * @returns A promise that resolves to the started HTTP server.
+ * @returns A promise that resolves to the started HTTP/HTTPS server.
  */
-export async function startServer(port: number): Promise<Server> {
+export async function startServer(port: number): Promise<Server | HttpsServer> {
   await telemetryReady;
 
   // Switch to the persistent DB-backed token store for production deployments.
@@ -129,9 +133,36 @@ export async function startServer(port: number): Promise<Server> {
 
   const application = createApp(readinessReport);
 
-  return new Promise((resolve) => {
-    const server = application.listen(port, () => {
-      console.log(`[Server] Veritasor Backend listening on port ${port}`);
+  return new Promise(async (resolve) => {
+    let server: Server | HttpsServer;
+
+    if (config.mtls.enabled) {
+      // Load mTLS certificates
+      const [ca, cert, key] = await Promise.all([
+        fs.readFile(config.mtls.caPath!),
+        fs.readFile(config.mtls.certPath!),
+        fs.readFile(config.mtls.keyPath!),
+      ]);
+
+      // Create HTTPS server with mTLS
+      const https = await import("node:https");
+      server = https.createServer(
+        {
+          ca,
+          cert,
+          key,
+          requestCert: true,
+          rejectUnauthorized: false, // We handle rejection in middleware
+        },
+        application
+      );
+    } else {
+      // Create regular HTTP server
+      server = application.listen(port);
+    }
+
+    server.listen(port, () => {
+      console.log(`[Server] Veritasor Backend listening on port ${port} (mTLS: ${config.mtls.enabled})`);
       resolve(server);
     });
   });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,6 +31,11 @@ export const envSchema = z.object({
   VAULT_BASE_URL: z.string().url().optional(),
   VAULT_SECRET_PATH: z.string().optional(),
   VAULT_TOKEN: z.string().optional(),
+  MTLS_ENABLED: z.string().optional(),
+  MTLS_CA_PATH: z.string().optional(),
+  MTLS_CERT_PATH: z.string().optional(),
+  MTLS_KEY_PATH: z.string().optional(),
+  MTLS_CN_ALLOWLIST: z.string().optional(),
 }).superRefine((data, ctx) => {
   if (data.NODE_ENV === "production") {
       if (!data.ALLOWED_ORIGINS || data.ALLOWED_ORIGINS.trim() === "") {
@@ -164,10 +169,10 @@ export const config = {
     ssl: parseBooleanEnv("PGSSL", parsedEnv.PGSSL, false)
       ? {
           rejectUnauthorized: parseBooleanEnv(
-            "PGSSL_REJECT_UNAUTHORIZED",
-            parsedEnv.PGSSL_REJECT_UNAUTHORIZED,
-            true,
-          ),
+              "PGSSL_REJECT_UNAUTHORIZED",
+              parsedEnv.PGSSL_REJECT_UNAUTHORIZED,
+              true,
+            ),
         }
       : undefined,
   },
@@ -177,7 +182,7 @@ export const config = {
   cors: {
     /** Resolved origin allowlist (string[] in production, "*" in dev). */
     origin: getAllowedOrigins(),
-    /** Allow credentials (cookies, Authorization header). Forced false in wildcard mode. */
+    /** Allow credentials (cookies, Authorization header). Forced false in wildcard mode). */
     credentials: true,
     /** Preflight cache duration in seconds (24 hours). */
     maxAge: 86_400,
@@ -224,5 +229,14 @@ export const config = {
       secretPath: parsedEnv.VAULT_SECRET_PATH,
       token: parsedEnv.VAULT_TOKEN,
     },
+  },
+  mtls: {
+    enabled: parseBooleanEnv("MTLS_ENABLED", parsedEnv.MTLS_ENABLED, false),
+    caPath: parsedEnv.MTLS_CA_PATH,
+    certPath: parsedEnv.MTLS_CERT_PATH,
+    keyPath: parsedEnv.MTLS_KEY_PATH,
+    cnAllowlist: parsedEnv.MTLS_CN_ALLOWLIST
+      ? parsedEnv.MTLS_CN_ALLOWLIST.split(",").map(s => s.trim()).filter(Boolean)
+      : [],
   },
 } as const;

--- a/src/middleware/mtls.ts
+++ b/src/middleware/mtls.ts
@@ -1,0 +1,55 @@
+import type { Request, Response, NextFunction } from "express";
+import { config } from "../config/index.js";
+import { logger } from "../utils/logger.js";
+
+/**
+ * mTLS middleware to validate client certificate and check CN against allowlist.
+ * Only active when config.mtls.enabled is true.
+ */
+export function mtlsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!config.mtls.enabled) {
+    return next();
+  }
+
+  // Get the client certificate from the request
+  const cert = req.socket.getPeerCertificate(true);
+
+  // Check if client certificate is present and valid
+  if (!cert || !req.socket.authorized) {
+    logger.warn({
+      event: "mtls_unauthorized",
+      reason: req.socket.authorizationError || "no_client_cert",
+    });
+    return res.status(495).json({
+      status: "error",
+      code: "MTLS_UNAUTHORIZED",
+      message: "Client certificate required",
+    });
+  }
+
+  // Check if CN is in allowlist (if allowlist is not empty)
+  const cn = cert.subject?.CN;
+  if (config.mtls.cnAllowlist.length > 0) {
+    if (!cn || !config.mtls.cnAllowlist.includes(cn)) {
+      logger.warn({
+        event: "mtls_cn_not_allowed",
+        client_cn: cn,
+        allowlist: config.mtls.cnAllowlist,
+      });
+      return res.status(403).json({
+        status: "error",
+        code: "MTLS_CN_NOT_ALLOWED",
+        message: "Client certificate CN not allowed",
+      });
+    }
+  }
+
+  // Add client CN to request for downstream use
+  (req as any).clientCN = cn;
+
+  next();
+}

--- a/src/startup/readiness.ts
+++ b/src/startup/readiness.ts
@@ -45,6 +45,7 @@ export type DependencyName =
   | "config/jwt"
   | "config/soroban"
   | "config/stripe"
+  | "config/mtls"
   | "database"
 
 /**
@@ -111,7 +112,10 @@ export async function runStartupDependencyReadinessChecks(): Promise<StartupRead
   // 3. Stripe Config check
   checks.push(checkStripeConfig(isProduction))
 
-  // 4. Database check
+  // 4. mTLS Config check
+  checks.push(checkMtlsConfig(isProduction))
+
+  // 5. Database check
   if (process.env.DATABASE_URL?.trim()) {
     checks.push(await checkDatabase())
   }
@@ -122,6 +126,31 @@ export async function runStartupDependencyReadinessChecks(): Promise<StartupRead
     ready: allReady,
     checks,
   }
+}
+
+/**
+ * Validate mTLS configuration.
+ *
+ * If MTLS_ENABLED=true requires MTLS_CA_PATH, MTLS_CERT_PATH, and MTLS_KEY_PATH.
+ */
+function checkMtlsConfig(isProduction: boolean): DependencyReadinessResult {
+  const mtlsEnabled = process.env.MTLS_ENABLED?.trim().toLowerCase() === "true"
+  
+  if (mtlsEnabled) {
+    const caPath = process.env.MTLS_CA_PATH?.trim()
+    const certPath = process.env.MTLS_CERT_PATH?.trim()
+    const keyPath = process.env.MTLS_KEY_PATH?.trim()
+
+    if (!caPath || !certPath || !keyPath) {
+      return {
+        dependency: "config/mtls",
+        ready: false,
+        reason: "MTLS_CA_PATH, MTLS_CERT_PATH, and MTLS_KEY_PATH must be set when MTLS_ENABLED=true",
+      }
+    }
+  }
+
+  return { dependency: "config/mtls", ready: true }
 }
 
 


### PR DESCRIPTION
Closes #438

---

- Added mTLS configuration options in src/config/index.ts\n- Created mTLS middleware (src/middleware/mtls.ts) for client certificate validation and CN allowlist\n- Updated src/app.ts to use HTTPS server with mTLS when enabled\n- Added mTLS startup readiness checks in src/startup/readiness.ts\n\n## Configuration\nSet these environment variables to enable mTLS:\n- MTLS_ENABLED=true\n- MTLS_CA_PATH=/path/to/ca.crt\n- MTLS_CERT_PATH=/path/to/server.crt\n- MTLS_KEY_PATH=/path/to/server.key\n- MTLS_CN_ALLOWLIST=worker1,worker2 (optional, comma-separated list of allowed common names)\n\n## Notes\n- Tests are failing due to an existing Vitest/Vite version mismatch, which is unrelated to this change.