### PR TITLE
feat: exponential backoff with full jitter for Soroban retries

### DIFF
--- a/src/services/soroban/client.ts
+++ b/src/services/soroban/client.ts
@@ -5,6 +5,7 @@ import {
   SorobanRetryBudgetExceededError,
   sorobanRetryBudget,
 } from "./retry-budget.js";
+import { traceSorobanRpcAttempt } from "../../tracing.js";
 
 export type SorobanClientConfig = {
   rpcUrl: string;
@@ -301,14 +302,24 @@ export function getSorobanRetryPolicy(
       MAX_RETRIES,
     ),
     retryBaseDelayMs: parseIntegerEnv(
-      "SOROBAN_RPC_RETRY_BASE_DELAY_MS",
-      DEFAULT_RETRY_POLICY.retryBaseDelayMs,
+      "SOROBAN_BACKOFF_BASE_MS",
+      parseIntegerEnv(
+        "SOROBAN_RPC_RETRY_BASE_DELAY_MS",
+        DEFAULT_RETRY_POLICY.retryBaseDelayMs,
+        MIN_DELAY_MS,
+        MAX_DELAY_MS,
+      ),
       MIN_DELAY_MS,
       MAX_DELAY_MS,
     ),
     retryMaxDelayMs: parseIntegerEnv(
-      "SOROBAN_RPC_RETRY_MAX_DELAY_MS",
-      DEFAULT_RETRY_POLICY.retryMaxDelayMs,
+      "SOROBAN_BACKOFF_MAX_MS",
+      parseIntegerEnv(
+        "SOROBAN_RPC_RETRY_MAX_DELAY_MS",
+        DEFAULT_RETRY_POLICY.retryMaxDelayMs,
+        MIN_DELAY_MS,
+        MAX_DELAY_MS,
+      ),
       MIN_DELAY_MS,
       MAX_DELAY_MS,
     ),
@@ -352,24 +363,29 @@ function sleep(delayMs: number): Promise<void> {
   });
 }
 
+/**
+ * Full-jitter exponential backoff.
+ *
+ * Implements the "Full Jitter" algorithm from the AWS Exponential Backoff
+ * blog post: delay = random(0, min(cap, base * 2^attempt)).
+ * This completely avoids thundering-herd problems because every retrying
+ * client picks a uniformly distributed delay within the window.
+ *
+ * @param attemptNumber - 1-based retry attempt number
+ * @param policy        - retry policy (base, cap)
+ * @param random        - PRNG returning values in [0, 1)
+ */
 function calculateRetryDelay(
   attemptNumber: number,
   policy: SorobanRetryPolicy,
   random: RandomFn,
 ): number {
-  const exponentialDelay = Math.min(
-    policy.retryBaseDelayMs * 2 ** (attemptNumber - 1),
+  const temp = Math.min(
     policy.retryMaxDelayMs,
+    policy.retryBaseDelayMs * 2 ** attemptNumber,
   );
-
-  if (policy.retryJitterRatio === 0) {
-    return exponentialDelay;
-  }
-
-  const jitterWindow = exponentialDelay * policy.retryJitterRatio;
-  const jitterOffset = (random() * 2 - 1) * jitterWindow;
-  const delayWithJitter = Math.round(exponentialDelay + jitterOffset);
-  return Math.max(MIN_DELAY_MS, delayWithJitter);
+  const delay = Math.round(random() * temp);
+  return Math.max(MIN_DELAY_MS, delay);
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -178,6 +178,7 @@ export async function traceSorobanRpcAttempt<T>(
         "rpc.system": "soroban",
         "rpc.method": operationName,
         "soroban.rpc.attempt": attempt,
+        "retry.attempt": attempt,
       },
     },
     async (span) => {

--- a/tests/unit/services/soroban/client.test.ts
+++ b/tests/unit/services/soroban/client.test.ts
@@ -120,6 +120,32 @@ describe('Soroban client retry and timeout policy', () => {
         'Invalid SOROBAN_RPC_TIMEOUT_MS. Expected an integer between 100 and 60000.',
       )
     })
+
+    it('reads backoff base from SOROBAN_BACKOFF_BASE_MS (new env name)', () => {
+      process.env.SOROBAN_BACKOFF_BASE_MS = '300'
+      process.env.SOROBAN_RPC_RETRY_BASE_DELAY_MS = '999'
+
+      expect(getSorobanRetryPolicy().retryBaseDelayMs).toBe(300)
+    })
+
+    it('reads backoff max from SOROBAN_BACKOFF_MAX_MS (new env name)', () => {
+      process.env.SOROBAN_BACKOFF_MAX_MS = '5000'
+      process.env.SOROBAN_RPC_RETRY_MAX_DELAY_MS = '9999'
+
+      expect(getSorobanRetryPolicy().retryMaxDelayMs).toBe(5000)
+    })
+
+    it('falls back to SOROBAN_RPC_RETRY_BASE_DELAY_MS when SOROBAN_BACKOFF_BASE_MS is unset', () => {
+      process.env.SOROBAN_RPC_RETRY_BASE_DELAY_MS = '150'
+
+      expect(getSorobanRetryPolicy().retryBaseDelayMs).toBe(150)
+    })
+
+    it('falls back to SOROBAN_RPC_RETRY_MAX_DELAY_MS when SOROBAN_BACKOFF_MAX_MS is unset', () => {
+      process.env.SOROBAN_RPC_RETRY_MAX_DELAY_MS = '2500'
+
+      expect(getSorobanRetryPolicy().retryMaxDelayMs).toBe(2500)
+    })
   })
 
   describe('isRetryableSorobanError', () => {
@@ -181,6 +207,7 @@ describe('Soroban client retry and timeout policy', () => {
           retryJitterRatio: 0,
         },
         sleep,
+        random: () => 1,
       })
 
       expect(result).toBe('ok')
@@ -189,7 +216,7 @@ describe('Soroban client retry and timeout policy', () => {
       expect(sleep).toHaveBeenCalledWith(5)
     })
 
-    it('applies jittered backoff while keeping the delay bounded', async () => {
+    it('applies full-jitter exponential backoff while keeping the delay bounded', async () => {
       const execute = vi
         .fn()
         .mockRejectedValueOnce(
@@ -212,7 +239,47 @@ describe('Soroban client retry and timeout policy', () => {
         random: () => 1,
       })
 
-      expect(sleep).toHaveBeenCalledWith(15)
+      // Full-jitter: delay = random(0, min(cap, base * 2^attempt))
+      // With attempt=1, base=10, cap=10: temp = min(10, 20) = 10, random=1 => 10
+      expect(sleep).toHaveBeenCalledWith(10)
+    })
+
+    it('produces deterministic full-jitter delays with a controlled random sequence', async () => {
+      const random = vi
+        .fn()
+        .mockReturnValueOnce(0.25)
+        .mockReturnValueOnce(0.75)
+      const execute = vi
+        .fn()
+        .mockRejectedValueOnce(
+          Object.assign(new Error('network error'), { code: 'ETIMEDOUT' }),
+        )
+        .mockRejectedValueOnce(
+          Object.assign(new Error('network error'), { code: 'ETIMEDOUT' }),
+        )
+        .mockResolvedValueOnce('ok')
+      const sleep = vi.fn(async () => undefined)
+
+      await executeSorobanRequest({
+        operationName: 'simulateTransaction',
+        execute,
+        policy: {
+          timeoutMs: 100,
+          maxRetries: 2,
+          retryBaseDelayMs: 100,
+          retryMaxDelayMs: 1000,
+          retryJitterRatio: 0,
+        },
+        sleep,
+        random,
+      })
+
+      // Full-jitter: delay = round(random * min(cap, base * 2^attempt))
+      // attempt=1: temp = min(1000, 200) = 200, random=0.25 => 50
+      // attempt=2: temp = min(1000, 400) = 400, random=0.75 => 300
+      expect(sleep).toHaveBeenCalledTimes(2)
+      expect(sleep).toHaveBeenNthCalledWith(1, 50)
+      expect(sleep).toHaveBeenNthCalledWith(2, 300)
     })
 
     it('retries a TRY_AGAIN_LATER response and returns the eventual success response', async () => {
@@ -240,6 +307,7 @@ describe('Soroban client retry and timeout policy', () => {
           retryJitterRatio: 0,
         },
         sleep,
+        random: () => 1,
       })
 
       expect(result).toEqual({

--- a/tests/unit/tracing.test.ts
+++ b/tests/unit/tracing.test.ts
@@ -115,6 +115,7 @@ describe("OpenTelemetry tracing helpers", () => {
       "rpc.system": "soroban",
       "rpc.method": "simulateTransaction",
       "soroban.rpc.attempt": 2,
+      "retry.attempt": 2,
       "error.type": "Error",
     });
     expect(JSON.stringify(spans[0].exceptions)).toContain("redacted");


### PR DESCRIPTION
close #416 
Replace fixed jitter with full-jitter exponential backoff to eliminate thundering-herd risk during Soroban RPC retries.

Implementation:

- Full-jitter: delay = random(0, min(cap, base * 2^attempt))

- Configurable via SOROBAN_BACKOFF_BASE_MS / SOROBAN_BACKOFF_MAX_MS (fall back to SOROBAN_RPC_RETRY_BASE_DELAY_MS / _MAX_DELAY_MS)

- Added retry.attempt attribute to OpenTelemetry spans

Also fixed a pre-existing bug: traceSorobanRpcAttempt was used but never imported in client.ts.