### PR TITLE
feat: add rebuild-indexer script for processing Soroban chain events …

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "migrate:rollback": "tsx src/db/migrate.ts rollback",
     "docs:routes": "tsx scripts/generate-routes.ts",
     "docs:openapi": "tsx scripts/generate-openapi.ts",
-    "audit:ci": "pnpm audit --prod --json | pnpm exec tsx scripts/check-audit.ts"
+    "audit:ci": "pnpm audit --prod --json | pnpm exec tsx scripts/check-audit.ts",
+    "rebuild:indexer": "tsx scripts/rebuild-indexer.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
@@ -22,6 +23,7 @@
     "@opentelemetry/sdk-node": "^0.57.2",
     "@stellar/stellar-sdk": "^14.5.0",
     "bcryptjs": "^2.4.3",
+    "commander": "^15.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
@@ -33,6 +35,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@cyclonedx/cyclonedx-npm": "^4.2.1",
     "@jest/globals": "^29.7.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
@@ -43,7 +46,6 @@
     "@types/pg": "^8.11.6",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^1.6.1",
-    "@cyclonedx/cyclonedx-npm": "^4.2.1",
     "eslint": "^9.15.0",
     "fast-check": "^4.6.0",
     "jest": "^30.2.0",
@@ -52,6 +54,7 @@
     "ts-jest": "^29.4.6",
     "tsx": "^4.19.2",
     "typescript": "~5.6.2",
+    "vite": "^6.4.3",
     "vitest": "^4.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -108,9 +111,12 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+      vite:
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -327,9 +333,9 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
@@ -339,9 +345,9 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -351,9 +357,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -363,9 +369,9 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -375,9 +381,9 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -387,9 +393,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -399,9 +405,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -411,9 +417,9 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -423,9 +429,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -435,9 +441,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -447,9 +453,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -459,9 +465,9 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -471,9 +477,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -483,9 +489,9 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -495,9 +501,9 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -507,9 +513,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -519,9 +525,9 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -531,15 +537,21 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
@@ -549,15 +561,21 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -567,15 +585,21 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -585,9 +609,9 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -597,9 +621,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -609,9 +633,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1898,6 +1922,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2115,9 +2143,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.4:
@@ -3949,21 +3977,26 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -3978,6 +4011,10 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vitest@4.1.8:
@@ -4355,148 +4392,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -5558,7 +5604,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5571,13 +5617,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.8(vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite: 6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -6015,6 +6061,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@15.0.0: {}
+
   commander@2.20.3:
     optional: true
 
@@ -6207,31 +6255,34 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.21.5:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -8505,20 +8556,25 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0):
+  vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.21.5
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.60.4
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.15
       fsevents: 2.3.3
       lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@1.6.1)(vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.8(vite@6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8535,7 +8591,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite: 6.4.3(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/scripts/rebuild-indexer.ts
+++ b/scripts/rebuild-indexer.ts
@@ -1,0 +1,464 @@
+#!/usr/bin/env tsx
+import { Command } from 'commander';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scValToNative } from '@stellar/stellar-sdk';
+import { rpc, xdr } from '@stellar/stellar-sdk';
+import { config } from '../src/config/index.js';
+import { pool } from '../src/db/client.js';
+import { logger } from '../src/utils/logger.js';
+import { createSorobanRpcServer } from '../src/services/soroban/client.js';
+
+const __filename = fileURLToPath(import.meta.url);
+
+export type AttestationStatus = 'pending' | 'submitted' | 'confirmed' | 'failed' | 'revoked';
+
+export interface RebuildOptions {
+  dryRun: boolean;
+  fromLedger?: number;
+  businessId?: string;
+  checkpointFile?: string;
+  useCheckpoint: boolean;
+  batchSize: number;
+}
+
+export interface CheckpointData {
+  cursor: string | null;
+  lastLedger: number;
+  processedCount: number;
+  updatedAt: string;
+}
+
+export interface RebuildStats {
+  totalEvents: number;
+  uniqueAttestations: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+}
+
+export interface ParsedEvent {
+  business: string;
+  period: string;
+  merkleRoot: string;
+  txHash: string;
+}
+
+const DEFAULT_CHECKPOINT_FILE = '.rebuild-indexer-checkpoint.json';
+const MAX_PAGE_SIZE = 100;
+const PACKAGE_VERSION = '0.1.0';
+
+export function loadCheckpoint(filePath: string): CheckpointData | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as CheckpointData;
+    if (parsed && typeof parsed.cursor === 'string' && typeof parsed.lastLedger === 'number') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCheckpoint(filePath: string, data: CheckpointData): void {
+  const dir = path.dirname(filePath);
+  if (dir && !fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+export function parseEventTopics(topics: xdr.ScVal[]): { business: string; period: string } | null {
+  try {
+    if (topics.length < 3) return null;
+
+    const eventName = scValToNative(topics[0]);
+    if (typeof eventName !== 'string') return null;
+
+    const business = scValToNative(topics[1]);
+    const period = scValToNative(topics[2]);
+
+    if (typeof business === 'string' && business.length > 0 &&
+        typeof period === 'string' && period.length > 0) {
+      return { business, period };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseEventValue(value: xdr.ScVal): { merkleRoot: string; timestamp?: number } | null {
+  try {
+    const native = scValToNative(value) as Record<string, unknown>;
+    if (!native || typeof native !== 'object') return null;
+
+    const merkleRoot = typeof native.merkle_root === 'string'
+      ? native.merkle_root
+      : typeof native.merkleRoot === 'string'
+        ? native.merkleRoot
+        : null;
+
+    if (!merkleRoot) return null;
+
+    const timestamp = native.timestamp !== undefined
+      ? Number(native.timestamp)
+      : undefined;
+
+    return { merkleRoot, timestamp };
+  } catch {
+    return null;
+  }
+}
+
+export function parseEventFromResponse(event: rpc.Api.EventResponse): ParsedEvent | null {
+  const topics = parseEventTopics(event.topic);
+  if (!topics) return null;
+
+  const value = parseEventValue(event.value);
+  if (!value) return null;
+
+  return {
+    business: topics.business,
+    period: topics.period,
+    merkleRoot: value.merkleRoot,
+    txHash: event.txHash,
+  };
+}
+
+export function buildAttestationId(businessId: string, period: string): string {
+  return `${businessId}:${period}`;
+}
+
+export async function fetchEvents(
+  server: rpc.Server,
+  contractId: string,
+  options: {
+    startLedger?: number;
+    cursor?: string;
+    batchSize: number;
+  },
+): Promise<{ events: rpc.Api.EventResponse[]; cursor: string; latestLedger: number }> {
+  const { startLedger, cursor, batchSize } = options;
+
+  const filters: rpc.Api.EventFilter[] = [
+    {
+      type: 'contract',
+      contractIds: [contractId],
+    },
+  ];
+
+  let request: rpc.Api.GetEventsRequest;
+
+  if (cursor) {
+    request = {
+      filters,
+      cursor,
+      limit: batchSize,
+    };
+  } else {
+    request = {
+      filters,
+      startLedger: startLedger ?? 1,
+      limit: batchSize,
+    };
+  }
+
+  const response = await server.getEvents(request);
+
+  return {
+    events: response.events,
+    cursor: response.cursor,
+    latestLedger: response.latestLedger,
+  };
+}
+
+export function shouldProcessEvent(
+  parsed: ParsedEvent,
+  businessIdFilter?: string,
+): boolean {
+  if (businessIdFilter && parsed.business !== businessIdFilter) {
+    return false;
+  }
+  return true;
+}
+
+export async function upsertAttestation(
+  client: { query: (sql: string, params?: any[]) => Promise<{ rows: any[] }> },
+  parsed: ParsedEvent,
+): Promise<{ action: 'created' | 'updated' | 'skipped' }> {
+  const sql = `
+    INSERT INTO attestations (business_id, period, merkle_root, tx_hash, status, version)
+    VALUES ($1, $2, $3, $4, 'confirmed', 1)
+    ON CONFLICT (business_id, period) DO UPDATE SET
+      merkle_root = EXCLUDED.merkle_root,
+      tx_hash = EXCLUDED.tx_hash,
+      status = 'confirmed',
+      version = attestations.version + 1
+    RETURNING id, version
+  `;
+
+  const result = await client.query(sql, [
+    parsed.business,
+    parsed.period,
+    parsed.merkleRoot,
+    parsed.txHash,
+  ]);
+
+  if (result.rows.length === 0) {
+    return { action: 'skipped' };
+  }
+
+  const row = result.rows[0];
+  return { action: row.version === 1 ? 'created' : 'updated' };
+}
+
+export async function processEvents(
+  server: rpc.Server,
+  dbClient: { query: (sql: string, params?: any[]) => Promise<{ rows: any[] }> },
+  contractId: string,
+  options: RebuildOptions,
+): Promise<RebuildStats> {
+  const stats: RebuildStats = {
+    totalEvents: 0,
+    uniqueAttestations: 0,
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  const seenAttestations = new Set<string>();
+
+  let cursor: string | undefined;
+  let startLedger: number | undefined = options.fromLedger;
+
+  if (options.useCheckpoint && options.checkpointFile) {
+    const cp = loadCheckpoint(options.checkpointFile);
+    if (cp && cp.cursor) {
+      cursor = cp.cursor;
+      startLedger = undefined;
+      logger.info({ cursor: cp.cursor, processedCount: cp.processedCount }, 'Resuming from checkpoint');
+    } else if (cp) {
+      logger.info({ lastLedger: cp.lastLedger }, 'Checkpoint found but no cursor, starting from beginning');
+    }
+  }
+
+  let hasMore = true;
+  let pageCount = 0;
+
+  while (hasMore) {
+    pageCount++;
+    logger.info({ page: pageCount, cursor: cursor || 'start' }, 'Fetching events page');
+
+    let fetchResult: { events: rpc.Api.EventResponse[]; cursor: string; latestLedger: number };
+
+    try {
+      fetchResult = await fetchEvents(server, contractId, {
+        startLedger,
+        cursor,
+        batchSize: options.batchSize,
+      });
+    } catch (err) {
+      logger.error({ err, page: pageCount }, 'Failed to fetch events page');
+      stats.errors++;
+      break;
+    }
+
+    const { events, cursor: newCursor, latestLedger } = fetchResult;
+
+    if (events.length === 0) {
+      logger.info({ latestLedger }, 'No more events to process');
+      hasMore = false;
+      break;
+    }
+
+    for (const event of events) {
+      stats.totalEvents++;
+
+      if (!event.inSuccessfulContractCall) {
+        continue;
+      }
+
+      let parsed: ParsedEvent | null;
+      try {
+        parsed = parseEventFromResponse(event);
+      } catch {
+        stats.errors++;
+        continue;
+      }
+
+      if (!parsed) {
+        stats.skipped++;
+        continue;
+      }
+
+      if (!shouldProcessEvent(parsed, options.businessId)) {
+        stats.skipped++;
+        continue;
+      }
+
+      const attestationId = buildAttestationId(parsed.business, parsed.period);
+
+      if (seenAttestations.has(attestationId)) {
+        stats.skipped++;
+        continue;
+      }
+      seenAttestations.add(attestationId);
+      stats.uniqueAttestations++;
+
+      if (options.dryRun) {
+        logger.info(
+          { business: parsed.business, period: parsed.period, merkleRoot: parsed.merkleRoot, txHash: parsed.txHash },
+          '[DRY-RUN] Would upsert attestation',
+        );
+        stats.created++;
+      } else {
+        try {
+          const result = await upsertAttestation(dbClient, parsed);
+          if (result.action === 'created') stats.created++;
+          else if (result.action === 'updated') stats.updated++;
+          else stats.skipped++;
+        } catch (err) {
+          logger.error(
+            { err, business: parsed.business, period: parsed.period },
+            'Failed to upsert attestation',
+          );
+          stats.errors++;
+        }
+      }
+    }
+
+    cursor = newCursor;
+
+    if (options.useCheckpoint && options.checkpointFile) {
+      saveCheckpoint(options.checkpointFile, {
+        cursor,
+        lastLedger: latestLedger,
+        processedCount: stats.totalEvents,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    if (events.length < (options.batchSize)) {
+      hasMore = false;
+    }
+  }
+
+  if (options.useCheckpoint && options.checkpointFile && cursor) {
+    saveCheckpoint(options.checkpointFile, {
+      cursor,
+      lastLedger: 0,
+      processedCount: stats.totalEvents,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  return stats;
+}
+
+function printStats(stats: RebuildStats, dryRun: boolean): void {
+  const prefix = dryRun ? '[DRY-RUN] ' : '';
+  console.log('');
+  console.log(`${prefix}Rebuild complete`);
+  console.log(`${prefix}  Total events scanned:  ${stats.totalEvents}`);
+  console.log(`${prefix}  Unique attestations:   ${stats.uniqueAttestations}`);
+  console.log(`${prefix}  Created:               ${stats.created}`);
+  console.log(`${prefix}  Updated:               ${stats.updated}`);
+  console.log(`${prefix}  Skipped:               ${stats.skipped}`);
+  console.log(`${prefix}  Errors:                ${stats.errors}`);
+}
+
+async function initDbClient() {
+  const client = await pool.connect();
+  return {
+    query: async (sql: string, params?: any[]) => {
+      return client.query(sql, params);
+    },
+    release: () => client.release(),
+  };
+}
+
+async function initSorobanServer(): Promise<rpc.Server> {
+  if (!config.soroban.rpcUrl) {
+    throw new Error('SOROBAN_RPC_URL is not configured');
+  }
+  return createSorobanRpcServer(config.soroban.rpcUrl);
+}
+
+export async function main(options?: Partial<RebuildOptions>): Promise<RebuildStats> {
+  const opts = {
+    dryRun: false,
+    useCheckpoint: true,
+    batchSize: MAX_PAGE_SIZE,
+    checkpointFile: DEFAULT_CHECKPOINT_FILE,
+    ...options,
+  } satisfies RebuildOptions;
+
+  if (!config.soroban.contractId) {
+    throw new Error('SOROBAN_CONTRACT_ID is not configured. Set it in your environment.');
+  }
+
+  const server = await initSorobanServer();
+  const dbClient = await initDbClient();
+
+  try {
+    const stats = await processEvents(server, dbClient, config.soroban.contractId, opts);
+    return stats;
+  } finally {
+    dbClient.release();
+    await pool.end();
+  }
+}
+
+if (process.argv[1] === __filename) {
+  const program = new Command();
+
+  program
+    .name('rebuild-indexer')
+    .description('Rebuild attestation indexer from Soroban chain events')
+    .version(PACKAGE_VERSION)
+    .option('--dry-run', 'Simulate without writing to database')
+    .option('--from-ledger <ledger>', 'Start ledger sequence', (v) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 1) throw new Error('--from-ledger must be a positive integer');
+      return n;
+    })
+    .option('--business-id <id>', 'Filter by specific business UUID')
+    .option('--checkpoint-file <path>', 'Checkpoint file path', DEFAULT_CHECKPOINT_FILE)
+    .option('--no-checkpoint', 'Disable checkpoint/resume')
+    .option('--batch-size <size>', 'Events per page (max 100)', (v) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 1 || n > 100) throw new Error('--batch-size must be between 1 and 100');
+      return n;
+    }, MAX_PAGE_SIZE)
+    .action(async (cliOpts) => {
+      const options: RebuildOptions = {
+        dryRun: cliOpts.dryRun ?? false,
+        fromLedger: cliOpts.fromLedger,
+        businessId: cliOpts.businessId,
+        checkpointFile: cliOpts.checkpointFile,
+        useCheckpoint: cliOpts.checkpoint ?? true,
+        batchSize: cliOpts.batchSize ?? MAX_PAGE_SIZE,
+      };
+
+      try {
+        const stats = await main(options);
+        printStats(stats, options.dryRun);
+        if (stats.errors > 0) {
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error('Fatal error:', err instanceof Error ? err.message : err);
+        process.exit(1);
+      }
+    });
+
+  program.parseAsync(process.argv).catch((err) => {
+    console.error('Fatal error:', err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/scripts/rebuild-indexer.test.ts
+++ b/tests/unit/scripts/rebuild-indexer.test.ts
@@ -1,0 +1,794 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { nativeToScVal } from '@stellar/stellar-sdk';
+
+vi.mock('../../../src/config/index.js', () => ({
+  config: {
+    soroban: {
+      contractId: 'CCJZ5DGAD65NFU3QY6Q6X2R5Q3Y4Q4Z5DGAD65NFU3QY6Q6X2R5Q3Y4',
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    },
+  },
+}));
+
+vi.mock('../../../src/db/client.js', () => ({
+  pool: {
+    connect: vi.fn(),
+    end: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/services/soroban/client.js', () => ({
+  createSorobanRpcServer: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const SAMPLE_MERKLE_ROOT = '0x' + 'a'.repeat(64);
+const SAMPLE_TX_HASH = '0x' + 'b'.repeat(64);
+const CONTRACT_ID = 'CCJZ5DGAD65NFU3QY6Q6X2R5Q3Y4Q4Z5DGAD65NFU3QY6Q6X2R5Q3Y4';
+
+function makeSymbolScVal(value: string) {
+  return nativeToScVal(value, { type: 'symbol' });
+}
+
+function makeStringScVal(value: string) {
+  return nativeToScVal(value, { type: 'string' });
+}
+
+function makeMapScVal(obj: Record<string, unknown>) {
+  return nativeToScVal(obj);
+}
+
+function makeMockEvent(overrides: {
+  business?: string;
+  period?: string;
+  merkleRoot?: string;
+  txHash?: string;
+  inSuccessfulContractCall?: boolean;
+  ledger?: number;
+} = {}) {
+  const business = overrides.business ?? 'business-123';
+  const period = overrides.period ?? '2026-01';
+  const merkleRoot = overrides.merkleRoot ?? SAMPLE_MERKLE_ROOT;
+  const txHash = overrides.txHash ?? SAMPLE_TX_HASH;
+
+  return {
+    id: `event-${business}-${period}`,
+    type: 'contract' as const,
+    ledger: overrides.ledger ?? 1000,
+    ledgerClosedAt: new Date().toISOString(),
+    transactionIndex: 0,
+    operationIndex: 0,
+    inSuccessfulContractCall: overrides.inSuccessfulContractCall ?? true,
+    txHash,
+    contractId: CONTRACT_ID,
+    topic: [
+      makeSymbolScVal('attestation_submitted'),
+      makeStringScVal(business),
+      makeStringScVal(period),
+    ],
+    value: makeMapScVal({ merkle_root: merkleRoot, timestamp: 1234567890 }),
+  };
+}
+
+import {
+  loadCheckpoint,
+  saveCheckpoint,
+  parseEventTopics,
+  parseEventValue,
+  parseEventFromResponse,
+  buildAttestationId,
+  shouldProcessEvent,
+  fetchEvents,
+  upsertAttestation,
+  processEvents as processEventsFn,
+  main,
+} from '../../../scripts/rebuild-indexer.js';
+
+describe('rebuild-indexer', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync('reindex-test-');
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    vi.clearAllMocks();
+  });
+
+  // ─── loadCheckpoint ──────────────────────────────────────────────────────
+
+  describe('loadCheckpoint', () => {
+    it('returns null when file does not exist', () => {
+      const result = loadCheckpoint('/nonexistent/path.json');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for corrupt JSON', () => {
+      const fp = path.join(tempDir, 'corrupt.json');
+      fs.writeFileSync(fp, '{invalid json}', 'utf-8');
+      expect(loadCheckpoint(fp)).toBeNull();
+    });
+
+    it('returns parsed data for valid checkpoint', () => {
+      const fp = path.join(tempDir, 'valid.json');
+      const data = { cursor: 'abc-123', lastLedger: 500, processedCount: 42, updatedAt: new Date().toISOString() };
+      fs.writeFileSync(fp, JSON.stringify(data), 'utf-8');
+      const result = loadCheckpoint(fp);
+      expect(result).not.toBeNull();
+      expect(result!.cursor).toBe('abc-123');
+      expect(result!.lastLedger).toBe(500);
+      expect(result!.processedCount).toBe(42);
+    });
+  });
+
+  // ─── saveCheckpoint ──────────────────────────────────────────────────────
+
+  describe('saveCheckpoint', () => {
+    it('writes checkpoint data to file', () => {
+      const fp = path.join(tempDir, 'checkpoint.json');
+      const data = { cursor: 'cur-1', lastLedger: 100, processedCount: 10, updatedAt: new Date().toISOString() };
+      saveCheckpoint(fp, data);
+      expect(fs.existsSync(fp)).toBe(true);
+      const saved = JSON.parse(fs.readFileSync(fp, 'utf-8'));
+      expect(saved.cursor).toBe('cur-1');
+      expect(saved.lastLedger).toBe(100);
+      expect(saved.processedCount).toBe(10);
+    });
+
+    it('creates parent directories if needed', () => {
+      const fp = path.join(tempDir, 'nested', 'dir', 'cp.json');
+      const data = { cursor: 'c', lastLedger: 1, processedCount: 0, updatedAt: new Date().toISOString() };
+      saveCheckpoint(fp, data);
+      expect(fs.existsSync(fp)).toBe(true);
+    });
+  });
+
+  // ─── parseEventTopics ────────────────────────────────────────────────────
+
+  describe('parseEventTopics', () => {
+    it('parses valid topics array', () => {
+      const topics = [
+        makeSymbolScVal('attestation_submitted'),
+        makeStringScVal('biz-001'),
+        makeStringScVal('2026-Q1'),
+      ];
+      const result = parseEventTopics(topics);
+      expect(result).not.toBeNull();
+      expect(result!.business).toBe('biz-001');
+      expect(result!.period).toBe('2026-Q1');
+    });
+
+    it('returns null for fewer than 3 topics', () => {
+      expect(parseEventTopics([makeSymbolScVal('ev')])).toBeNull();
+      expect(parseEventTopics([makeSymbolScVal('ev'), makeStringScVal('b')])).toBeNull();
+    });
+
+    it('returns null when first topic is not a symbol (non-string-convertible)', () => {
+      const topics = [makeMapScVal({}), makeStringScVal('biz'), makeStringScVal('p')];
+      const result = parseEventTopics(topics as any);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when business is empty string', () => {
+      const topics = [
+        makeSymbolScVal('ev'),
+        makeStringScVal(''),
+        makeStringScVal('2026-01'),
+      ];
+      expect(parseEventTopics(topics)).toBeNull();
+    });
+
+    it('returns null when period is empty string', () => {
+      const topics = [
+        makeSymbolScVal('ev'),
+        makeStringScVal('biz-1'),
+        makeStringScVal(''),
+      ];
+      expect(parseEventTopics(topics)).toBeNull();
+    });
+
+    it('returns null on ScVal conversion error', () => {
+      const topics = [{} as any, {} as any, {} as any];
+      expect(parseEventTopics(topics)).toBeNull();
+    });
+  });
+
+  // ─── parseEventValue ─────────────────────────────────────────────────────
+
+  describe('parseEventValue', () => {
+    it('parses value with merkle_root and timestamp', () => {
+      const value = makeMapScVal({ merkle_root: '0xabc', timestamp: 1234567890 });
+      const result = parseEventValue(value);
+      expect(result).not.toBeNull();
+      expect(result!.merkleRoot).toBe('0xabc');
+      expect(result!.timestamp).toBe(1234567890);
+    });
+
+    it('parses value with camelCase merkleRoot', () => {
+      const value = makeMapScVal({ merkleRoot: '0xdef' });
+      const result = parseEventValue(value);
+      expect(result).not.toBeNull();
+      expect(result!.merkleRoot).toBe('0xdef');
+    });
+
+    it('returns null when merkle_root is missing', () => {
+      const value = makeMapScVal({ timestamp: 999 });
+      expect(parseEventValue(value)).toBeNull();
+    });
+
+    it('returns null for non-map value (string)', () => {
+      const value = makeStringScVal('hello');
+      const result = parseEventValue(value);
+      expect(result).toBeNull();
+    });
+
+    it('returns null on ScVal conversion error', () => {
+      expect(parseEventValue({} as any)).toBeNull();
+    });
+  });
+
+  // ─── parseEventFromResponse ──────────────────────────────────────────────
+
+  describe('parseEventFromResponse', () => {
+    it('parses a valid event response', () => {
+      const event = makeMockEvent({ business: 'biz-x', period: '2026-02', merkleRoot: '0xabc' });
+      const result = parseEventFromResponse(event as any);
+      expect(result).not.toBeNull();
+      expect(result!.business).toBe('biz-x');
+      expect(result!.period).toBe('2026-02');
+      expect(result!.merkleRoot).toBe('0xabc');
+      expect(result!.txHash).toBe(SAMPLE_TX_HASH);
+    });
+
+    it('returns null when topics cannot be parsed', () => {
+      const event = makeMockEvent();
+      event.topic = [makeSymbolScVal('ev')];
+      const result = parseEventFromResponse(event as any);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when value cannot be parsed', () => {
+      const event = makeMockEvent();
+      event.value = makeStringScVal('no-map');
+      const result = parseEventFromResponse(event as any);
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── buildAttestationId ──────────────────────────────────────────────────
+
+  describe('buildAttestationId', () => {
+    it('returns colon-delimited composite key', () => {
+      expect(buildAttestationId('biz-a', '2026-01')).toBe('biz-a:2026-01');
+    });
+  });
+
+  // ─── shouldProcessEvent ──────────────────────────────────────────────────
+
+  describe('shouldProcessEvent', () => {
+    const parsed = { business: 'biz-1', period: '2026-01', merkleRoot: '0x', txHash: '0x' };
+
+    it('returns true when no filter is set', () => {
+      expect(shouldProcessEvent(parsed, undefined)).toBe(true);
+    });
+
+    it('returns true when business matches filter', () => {
+      expect(shouldProcessEvent(parsed, 'biz-1')).toBe(true);
+    });
+
+    it('returns false when business does not match filter', () => {
+      expect(shouldProcessEvent(parsed, 'other-biz')).toBe(false);
+    });
+  });
+
+  // ─── fetchEvents ─────────────────────────────────────────────────────────
+
+  describe('fetchEvents', () => {
+    it('fetches events with startLedger when no cursor', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValue({
+          events: [makeMockEvent()],
+          cursor: 'cursor-1',
+          latestLedger: 1500,
+        }),
+      };
+
+      const result = await fetchEvents(mockServer as any, CONTRACT_ID, {
+        startLedger: 100,
+        batchSize: 50,
+      });
+
+      expect(mockServer.getEvents).toHaveBeenCalledWith({
+        filters: [{ type: 'contract', contractIds: [CONTRACT_ID] }],
+        startLedger: 100,
+        limit: 50,
+      });
+      expect(result.events).toHaveLength(1);
+      expect(result.cursor).toBe('cursor-1');
+      expect(result.latestLedger).toBe(1500);
+    });
+
+    it('fetches events with cursor when provided', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValue({
+          events: [],
+          cursor: 'cursor-2',
+          latestLedger: 2000,
+        }),
+      };
+
+      const result = await fetchEvents(mockServer as any, CONTRACT_ID, {
+        cursor: 'prev-cursor',
+        batchSize: 100,
+      });
+
+      expect(mockServer.getEvents).toHaveBeenCalledWith({
+        filters: [{ type: 'contract', contractIds: [CONTRACT_ID] }],
+        cursor: 'prev-cursor',
+        limit: 100,
+      });
+      expect(result.events).toHaveLength(0);
+      expect(result.cursor).toBe('cursor-2');
+    });
+
+    it('defaults startLedger to 1 when not provided', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValue({
+          events: [],
+          cursor: '',
+          latestLedger: 10,
+        }),
+      };
+
+      await fetchEvents(mockServer as any, CONTRACT_ID, { batchSize: 10 });
+      expect(mockServer.getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ startLedger: 1 }),
+      );
+    });
+  });
+
+  // ─── upsertAttestation ───────────────────────────────────────────────────
+
+  describe('upsertAttestation', () => {
+    it('performs INSERT and returns created action', async () => {
+      const mockClient = {
+        query: vi.fn().mockResolvedValue({
+          rows: [{ id: 'new-id', version: 1 }],
+        }),
+      };
+      const parsed = { business: 'biz-1', period: '2026-01', merkleRoot: '0xabc', txHash: '0xdef' };
+      const result = await upsertAttestation(mockClient, parsed);
+      expect(result.action).toBe('created');
+      expect(mockClient.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO attestations'),
+        ['biz-1', '2026-01', '0xabc', '0xdef'],
+      );
+    });
+
+    it('performs UPDATE and returns updated action', async () => {
+      const mockClient = {
+        query: vi.fn().mockResolvedValue({
+          rows: [{ id: 'existing-id', version: 3 }],
+        }),
+      };
+      const parsed = { business: 'biz-2', period: '2026-02', merkleRoot: '0xnew', txHash: '0xnew' };
+      const result = await upsertAttestation(mockClient, parsed);
+      expect(result.action).toBe('updated');
+    });
+
+    it('returns skipped when no rows returned', async () => {
+      const mockClient = {
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      };
+      const parsed = { business: 'biz-3', period: '2026-03', merkleRoot: '0xabc', txHash: '0xdef' };
+      const result = await upsertAttestation(mockClient, parsed);
+      expect(result.action).toBe('skipped');
+    });
+  });
+
+  // ─── processEvents ───────────────────────────────────────────────────────
+
+  describe('processEvents', () => {
+    it('processes events and upserts unique attestations', async () => {
+      const mockServer = {
+        getEvents: vi.fn()
+          .mockResolvedValueOnce({
+            events: [
+              makeMockEvent({ business: 'biz-a', period: '2026-01' }),
+              makeMockEvent({ business: 'biz-b', period: '2026-01' }),
+            ],
+            cursor: 'page-1',
+            latestLedger: 500,
+          })
+          .mockResolvedValueOnce({
+            events: [],
+            cursor: 'page-2',
+            latestLedger: 501,
+          }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(2);
+      expect(stats.uniqueAttestations).toBe(2);
+      expect(stats.created).toBe(2);
+      expect(stats.updated).toBe(0);
+      expect(stats.errors).toBe(0);
+      expect(mockDbClient.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates same business+period from different events', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [
+            makeMockEvent({ business: 'biz-a', period: '2026-01' }),
+            makeMockEvent({ business: 'biz-a', period: '2026-01' }),
+          ],
+          cursor: 'end',
+          latestLedger: 300,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(2);
+      expect(stats.uniqueAttestations).toBe(1);
+      expect(stats.created).toBe(1);
+      expect(mockDbClient.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters events by businessId', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [
+            makeMockEvent({ business: 'target-biz', period: '2026-01' }),
+            makeMockEvent({ business: 'other-biz', period: '2026-01' }),
+          ],
+          cursor: 'end',
+          latestLedger: 400,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100, businessId: 'target-biz' },
+      );
+
+      expect(stats.totalEvents).toBe(2);
+      expect(stats.uniqueAttestations).toBe(1);
+      expect(stats.skipped).toBe(1); // the non-matching one
+      expect(mockDbClient.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips events from unsuccessful contract calls', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [
+            makeMockEvent({ business: 'biz-a', period: '2026-01', inSuccessfulContractCall: false }),
+          ],
+          cursor: 'end',
+          latestLedger: 500,
+        }),
+      };
+
+      const mockDbClient = { query: vi.fn() };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(1);
+      expect(stats.uniqueAttestations).toBe(0);
+      expect(mockDbClient.query).not.toHaveBeenCalled();
+    });
+
+    it('handles dry-run mode without writing to DB', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [makeMockEvent({ business: 'biz-dry', period: '2026-01' })],
+          cursor: 'end',
+          latestLedger: 600,
+        }),
+      };
+
+      const mockDbClient = { query: vi.fn() };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: true, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(1);
+      expect(stats.uniqueAttestations).toBe(1);
+      expect(stats.created).toBe(1);
+      expect(mockDbClient.query).not.toHaveBeenCalled();
+    });
+
+    it('handles fetch error gracefully', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockRejectedValue(new Error('RPC timeout')),
+      };
+
+      const mockDbClient = { query: vi.fn() };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.errors).toBe(1);
+      expect(stats.totalEvents).toBe(0);
+    });
+
+    it('handles upsert error gracefully', async () => {
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [makeMockEvent({ business: 'biz-err', period: '2026-01' })],
+          cursor: 'end',
+          latestLedger: 700,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockRejectedValue(new Error('DB deadlock')),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(1);
+      expect(stats.errors).toBe(1);
+    });
+
+    it('saves checkpoint periodically', async () => {
+      const cpFile = path.join(tempDir, 'cp.json');
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [makeMockEvent({ business: 'biz-cp', period: '2026-01' })],
+          cursor: 'cp-cursor-1',
+          latestLedger: 800,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: true, checkpointFile: cpFile, batchSize: 100 },
+      );
+
+      expect(fs.existsSync(cpFile)).toBe(true);
+      const cp = JSON.parse(fs.readFileSync(cpFile, 'utf-8'));
+      expect(cp.cursor).toBe('cp-cursor-1');
+    });
+
+    it('resumes from checkpoint when available', async () => {
+      const cpFile = path.join(tempDir, 'resume-cp.json');
+      fs.writeFileSync(cpFile, JSON.stringify({
+        cursor: 'resume-cur',
+        lastLedger: 900,
+        processedCount: 50,
+        updatedAt: new Date().toISOString(),
+      }));
+
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [],
+          cursor: 'next-cur',
+          latestLedger: 1000,
+        }),
+      };
+
+      const mockDbClient = { query: vi.fn() };
+
+      await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: true, checkpointFile: cpFile, batchSize: 100 },
+      );
+
+      expect(mockServer.getEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ cursor: 'resume-cur' }),
+      );
+    });
+
+    it('starts from beginning when checkpoint has no cursor', async () => {
+      const cpFile = path.join(tempDir, 'no-cursor-cp.json');
+      fs.writeFileSync(cpFile, JSON.stringify({
+        cursor: null,
+        lastLedger: 500,
+        processedCount: 100,
+        updatedAt: new Date().toISOString(),
+      }));
+
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [makeMockEvent({ business: 'biz-fresh', period: '2026-01' })],
+          cursor: 'new-cur',
+          latestLedger: 600,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: true, checkpointFile: cpFile, batchSize: 100 },
+      );
+
+      expect(mockServer.getEvents).toHaveBeenCalledWith(
+        expect.not.objectContaining({ cursor: expect.any(String) }),
+      );
+    });
+
+    it('continues pagination when events fill a full page', async () => {
+      const events = Array.from({ length: 2 }, (_, i) =>
+        makeMockEvent({ business: `biz-page-${i}`, period: '2026-01' })
+      );
+
+      const mockServer = {
+        getEvents: vi.fn()
+          .mockResolvedValueOnce({
+            events,
+            cursor: 'page-1-cur',
+            latestLedger: 300,
+          })
+          .mockResolvedValueOnce({
+            events: [makeMockEvent({ business: 'biz-page-next', period: '2026-01' })],
+            cursor: 'page-2-cur',
+            latestLedger: 301,
+          }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 2 },
+      );
+
+      expect(stats.totalEvents).toBe(3);
+      expect(stats.uniqueAttestations).toBe(3);
+      expect(mockDbClient.query).toHaveBeenCalledTimes(3);
+      expect(mockServer.getEvents).toHaveBeenCalledTimes(2);
+      expect(mockServer.getEvents).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: 'page-1-cur' }));
+    });
+
+    it('handles event parse error gracefully without failing the page', async () => {
+      const validEvent = makeMockEvent({ business: 'biz-ok', period: '2026-01' });
+      const badEvent = makeMockEvent({ business: 'biz-bad', period: '2026-01' });
+      badEvent.value = {} as any;
+
+      const mockServer = {
+        getEvents: vi.fn().mockResolvedValueOnce({
+          events: [badEvent, validEvent],
+          cursor: 'end',
+          latestLedger: 400,
+        }),
+      };
+
+      const mockDbClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+      };
+
+      const stats = await processEventsFn(
+        mockServer as any,
+        mockDbClient,
+        CONTRACT_ID,
+        { dryRun: false, useCheckpoint: false, batchSize: 100 },
+      );
+
+      expect(stats.totalEvents).toBe(2);
+      expect(stats.skipped).toBe(1);
+      expect(stats.uniqueAttestations).toBe(1);
+    });
+  });
+
+  // ─── main ────────────────────────────────────────────────────────────────
+
+  describe('main', () => {
+    it('throws when contractId is not configured', async () => {
+      // Temporarily override config mock
+      const configModule = await import('../../../src/config/index.js');
+      const originalContractId = (configModule.config as any).soroban.contractId;
+      (configModule.config as any).soroban.contractId = '';
+
+      await expect(main({ dryRun: true, useCheckpoint: false })).rejects.toThrow(
+        'SOROBAN_CONTRACT_ID is not configured',
+      );
+
+      (configModule.config as any).soroban.contractId = originalContractId;
+    });
+
+    it('creates soroban server and db client, processes events, and cleans up', async () => {
+      const { pool: mockPool } = await import('../../../src/db/client.js');
+      const { createSorobanRpcServer: mockCreateServer } = await import(
+        '../../../src/services/soroban/client.js'
+      );
+
+      const mockQueryClient = {
+        query: vi.fn().mockResolvedValue({ rows: [{ id: 'x', version: 1 }] }),
+        release: vi.fn(),
+      };
+
+      vi.mocked(mockPool.connect).mockResolvedValue(mockQueryClient);
+
+      const mockGetEvents = vi.fn().mockResolvedValueOnce({
+        events: [makeMockEvent({ business: 'biz-main', period: '2026-01' })],
+        cursor: 'end',
+        latestLedger: 100,
+      });
+
+      vi.mocked(mockCreateServer).mockReturnValue({
+        getEvents: mockGetEvents,
+      } as any);
+
+      const stats = await main({ dryRun: false, useCheckpoint: false, batchSize: 100 });
+
+      expect(stats.totalEvents).toBe(1);
+      expect(stats.created).toBe(1);
+      expect(mockPool.connect).toHaveBeenCalled();
+      expect(mockQueryClient.release).toHaveBeenCalled();
+      expect(mockPool.end).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #418 

# Pull Request: Attestation Indexer Rebuild CLI for Disaster Recovery

## Overview
This PR implements a CLI tool (`scripts/rebuild-indexer.ts`) that walks Soroban contract events and reconstructs the attestations table from chain state. Used to recover from data corruption, migration failure, or to backfill missing records.

Closes #418.

## Key Changes

### 1. CLI Tool (`scripts/rebuild-indexer.ts`)
- **Commander-based CLI** with the following options:
  - `--dry-run` — simulate without writing to the database
  - `--from-ledger <n>` — start scanning from a specific ledger sequence
  - `--business-id <uuid>` — filter events for a single business
  - `--checkpoint-file <path>` / `--no-checkpoint` — save/resume progress via JSON checkpoint
  - `--batch-size <n>` — events per RPC page (max 100)
- **Soroban Event Streaming**: Uses `server.getEvents()` with paginated cursor to iterate contract events from the RPC node.
- **Event Parsing**: Decodes ScVal topics (`Symbol`, `String`, `String`) and value (`Map` with `merkle_root`) using `scValToNative` from `@stellar/stellar-sdk`.
- **Upsert Logic**: `INSERT ... ON CONFLICT (business_id, period) DO UPDATE` with version increment for conflict resolution.
- **Checkpoint/Resume**: Persists cursor to a JSON file after each page; resumes from last cursor on re-run.
- **Deduplication**: Tracks seen `business_id:period` pairs to avoid redundant upserts when multiple events reference the same attestation.

### 2. Package & Config
- Added `commander` (v15.0.0) dependency for CLI argument parsing.
- Added `"rebuild:indexer": "tsx scripts/rebuild-indexer.ts"` npm script.
- Upgraded `vite` to `^6.0.0` for vitest 4.x compatibility.

### 3. Testing (`tests/unit/scripts/rebuild-indexer.test.ts`)
- **43 unit tests** covering all functional paths:
  - Checkpoint load/save (missing file, corrupt JSON, valid, directory creation)
  - Event topic parsing (valid, wrong count, non-string, empty fields, ScVal errors)
  - Event value parsing (snake_case `merkle_root`, camelCase `merkleRoot`, missing fields, non-map values)
  - Fetch events (startLedger, cursor mode, defaults)
  - Upsert (insert new, update existing, skipped)
  - Process events (normal flow, deduplication, business filter, unsuccessful contract calls, dry-run, fetch errors, upsert errors, checkpoint save/resume, pagination continuation, parse error resilience)
  - Main entry point (missing contract ID, full integration with mocked dependencies)
- All pure functions are isolated for direct testing without mocking.

## Security & Correctness
- **Parameterized Queries**: All SQL uses `$1`, `$2` placeholders — no string concatenation, preventing SQL injection.
- **ScVal Decoding**: `scValToNative` is called inside try/catch blocks; malformed events are skipped without crashing.
- **Dry-Run Mode**: Allows inspection of all discovered attestations before any writes occur.
- **Checkpoint Integrity**: Checkpoint validation checks `typeof cursor === 'string'` and `typeof lastLedger === 'number'` before accepting a resume.
- **No Implicit Secrets**: The script uses existing `config.soroban` and `pool` — no new credential paths introduced.

## Verification Results
- **Tests**: 43/43 passed.
- **Existing Test Compatibility**: All pre-existing unit tests continue to pass (102 tests across rebuild-indexer + attestation repository suites).
- **Edge Cases Covered**:
  - Empty event pages terminate gracefully
  - RPC errors log and break without infinite retry
  - Upsert errors log and continue to next event
  - Duplicate events from same attestation are deduplicated
  - Partial runs resume from checkpoint cursor
  - Checkpoint with null cursor starts from beginning

## Usage
```bash
# Dry run to see what would be indexed
pnpm rebuild:indexer -- --dry-run --from-ledger 1000

# Full rebuild from a specific ledger
pnpm rebuild:indexer -- --from-ledger 1000

# Rebuild for a single business
pnpm rebuild:indexer -- --business-id <uuid>

# Resume from checkpoint
pnpm rebuild:indexer

# Disable checkpoint
pnpm rebuild:indexer -- --no-checkpoint
```

