### PR TITLE
feat: attach trace-id exemplars to Prometheus histograms

### DIFF
--- a/docs/metrics-exemplars.md
+++ b/docs/metrics-exemplars.md
@@ -1,0 +1,29 @@
+# Prometheus exemplars for trace correlation
+
+The HTTP request duration histogram now emits exemplars that carry the active OpenTelemetry trace ID. This allows Grafana to link a spike in the histogram directly to the matching trace when the trace backend is configured.
+
+## How it works
+
+- The request logger observes the histogram at response time.
+- The active span context is read from the current OpenTelemetry context.
+- When a valid trace is present, the histogram attaches an exemplar label named `trace_id`.
+- When no span is active, the exemplar is omitted and the histogram records the sample normally.
+
+## Security and cardinality considerations
+
+- Only the trace ID is attached as an exemplar label. No request headers, bodies, or other user-controlled values are exported.
+- Trace IDs are bounded by the number of in-flight requests and the trace sampling policy, which keeps exemplar cardinality controlled.
+- The implementation intentionally avoids adding per-request labels such as route or method to exemplars to prevent unbounded growth.
+
+## Grafana link configuration
+
+A typical Grafana link can use the exemplar value directly:
+
+```json
+{
+  "title": "Open trace",
+  "url": "https://your-tracing-ui.example/trace/$__value.raw"
+}
+```
+
+If your tracing UI expects a different query parameter, substitute the placeholder accordingly. The key point is that the exemplar value is the trace ID emitted by the metric.

--- a/src/metrics.spec.ts
+++ b/src/metrics.spec.ts
@@ -1,0 +1,67 @@
+import { trace, type Span, type SpanContext } from "@opentelemetry/api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  httpRequestDuration,
+  observeHttpRequestDuration,
+} from "./metrics.js";
+import { getActiveTraceExemplarLabels } from "./tracing.js";
+
+const TRACE_ID = "11111111111111111111111111111111";
+const SPAN_ID = "2222222222222222";
+
+function withFakeSpan<T>(spanContext: SpanContext, callback: () => T): T {
+  const fakeSpan = {
+    spanContext: () => spanContext,
+  } as Span;
+
+  const getActiveSpanSpy = vi
+    .spyOn(trace, "getActiveSpan")
+    .mockReturnValue(fakeSpan);
+
+  try {
+    return callback();
+  } finally {
+    getActiveSpanSpy.mockRestore();
+  }
+}
+
+describe("HTTP request metrics exemplars", () => {
+  beforeEach(() => {
+    httpRequestDuration.reset();
+  });
+
+  it("returns no exemplar labels when there is no active span", () => {
+    expect(getActiveTraceExemplarLabels()).toEqual({});
+  });
+
+  it("drops exemplars when there is no active span", () => {
+    observeHttpRequestDuration(
+      { method: "GET", route: "/health", status_code: "200" },
+      0.25,
+    );
+
+    const bucketValues = Object.values(httpRequestDuration.hashMap)[0];
+    expect(bucketValues.bucketExemplars[0.25]).toBeNull();
+  });
+
+  it("attaches the active trace id as an exemplar when a span is active", () => {
+    const spanContext: SpanContext = {
+      traceId: TRACE_ID,
+      spanId: SPAN_ID,
+      traceFlags: 1,
+      isRemote: false,
+    };
+
+    withFakeSpan(spanContext, () => {
+      observeHttpRequestDuration(
+        { method: "GET", route: "/health", status_code: "200" },
+        0.25,
+      );
+    });
+
+    const bucketValues = Object.values(httpRequestDuration.hashMap)[0];
+    expect(bucketValues.bucketExemplars[0.25]).toMatchObject({
+      labelSet: { trace_id: TRACE_ID },
+    });
+  });
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,14 +1,34 @@
 import { Registry, Histogram, Counter, Gauge } from "prom-client";
+import { getActiveTraceExemplarLabels } from "./tracing.js";
 
 export const metricsRegistry = new Registry();
+metricsRegistry.setContentType(Registry.OPENMETRICS_CONTENT_TYPE);
 
 export const httpRequestDuration = new Histogram({
   name: "http_request_duration_seconds",
   help: "HTTP request duration in seconds",
   labelNames: ["method", "route", "status_code"] as const,
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  enableExemplars: true,
   registers: [metricsRegistry],
 });
+
+export function observeHttpRequestDuration(
+  labels: Record<string, string>,
+  durationSec: number,
+): void {
+  const exemplarLabels = getActiveTraceExemplarLabels();
+  if (Object.keys(exemplarLabels).length === 0) {
+    httpRequestDuration.observe({ labels, value: durationSec });
+    return;
+  }
+
+  httpRequestDuration.observe({
+    labels,
+    value: durationSec,
+    exemplarLabels,
+  });
+}
 
 export const rateLimitRejections = new Counter({
   name: "http_rate_limit_rejections_total",

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { logger, runWithLoggerContext } from "../utils/logger.js";
 import { randomUUID } from "crypto";
-import { httpRequestDuration } from "../metrics.js";
+import { observeHttpRequestDuration } from "../metrics.js";
 import { startHttpRequestSpan } from "../tracing.js";
 
 /**
@@ -123,7 +123,7 @@ export function requestLogger(req: Request, res: Response, next: NextFunction) {
         const durationSec = sec + nano / 1e9;
 
         const route = (req.route?.path as string | undefined) ?? req.path;
-        httpRequestDuration.observe(
+        observeHttpRequestDuration(
           { method: req.method, route, status_code: String(res.statusCode) },
           durationSec,
         );

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -2,6 +2,7 @@ import {
   SpanKind,
   SpanStatusCode,
   context,
+  isSpanContextValid,
   propagation,
   trace,
   type Context,
@@ -109,6 +110,19 @@ export function getHttpRequestContext(req: Request): Context {
   }
 
   return propagation.extract(context.active(), req.headers, HTTP_HEADER_GETTER);
+}
+
+export function getActiveTraceExemplarLabels(): Record<string, string> {
+  const activeSpan = trace.getActiveSpan();
+  const spanContext = activeSpan?.spanContext();
+
+  if (!spanContext || !isSpanContextValid(spanContext)) {
+    return {};
+  }
+
+  return {
+    trace_id: spanContext.traceId,
+  };
 }
 
 export function startHttpRequestSpan(


### PR DESCRIPTION
closes #540 
## Summary
This PR adds Prometheus exemplars to the HTTP request duration histogram so Grafana can link a metric spike directly to the corresponding OpenTelemetry trace ID.

## What changed
- Enabled exemplars on the request-duration histogram
- Attached the active trace ID as an exemplar label when a valid span is present
- Safely omitted exemplars when no active span is available
- Added regression tests covering both the no-span and active-span paths
- Documented the Grafana linking approach and the security/cardinality rationale

## Why
On-call operators can now jump from a histogram spike to the underlying trace more quickly, which improves incident investigation and reduces time to root cause.

## Testing
- Verified with:
  - `pnpm vitest run src/metrics.spec.ts`

## Notes
- The exemplar payload is intentionally limited to the trace ID to keep cardinality bounded and avoid exporting sensitive request data.

