### PR TITLE
feat: auto-renew Vault dynamic secret leases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,30 @@ NODE_ENV=development
 # ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 
 # ------------------------------------------------------------------------------
+# Secrets Provider
+# ------------------------------------------------------------------------------
+
+# Where JWT/webhook/etc. secrets are loaded from: env (default), aws, or vault.
+# Note: this is read directly from SECRET_PROVIDER by src/utils/secret-loader.ts;
+# it is a separate setting from the SECRET_LOADER variable validated in
+# src/config/index.ts (pre-existing naming inconsistency between the two).
+# SECRET_PROVIDER=env
+
+# Required when SECRET_PROVIDER=vault.
+# VAULT_BASE_URL=https://vault.example.com
+# VAULT_SECRET_PATH=secret/data/veritasor-backend
+# VAULT_TOKEN=
+
+# When Vault returns a renewable dynamic-secret lease (lease_id + a positive
+# lease_duration + renewable: true), VaultAdapter automatically renews it at
+# 70% of its lease_duration (with jitter to avoid a thundering herd across
+# instances). If Vault denies renewal, it falls back to a full reload,
+# rotating in-memory secrets from a freshly-issued lease. No configuration
+# needed — this is automatic whenever SECRET_PROVIDER=vault and Vault's
+# response is renewable. See vault_lease_renewal_total /
+# vault_lease_seconds_remaining in src/metrics.ts.
+
+# ------------------------------------------------------------------------------
 # Database
 # ------------------------------------------------------------------------------
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -237,6 +237,14 @@ export const config = {
   secretLoader: {
     source: parsedEnv.SECRET_LOADER,
     filePath: parsedEnv.SECRET_FILE_PATH,
+    /**
+     * When `source` is `"vault"`, `VaultAdapter` (src/utils/secret-loader.ts)
+     * auto-renews any renewable dynamic-secret lease Vault returns at 70% of
+     * its `lease_duration` (with jitter), and falls back to a full reload —
+     * rotating in-memory secrets from a fresh lease — if Vault denies
+     * renewal. See `vault_lease_renewal_total` / `vault_lease_seconds_remaining`
+     * in src/metrics.ts for observability into this.
+     */
     vault: {
       baseUrl: parsedEnv.VAULT_BASE_URL,
       secretPath: parsedEnv.VAULT_SECRET_PATH,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -71,3 +71,33 @@ export const idempotencySweepRunsTotal = new Counter({
   labelNames: ["backend", "outcome"] as const,
   registers: [metricsRegistry],
 });
+
+/**
+ * Vault dynamic-secret lease renewal metrics.
+ *
+ * See `VaultAdapter` in `src/utils/secret-loader.ts`: dynamic Vault secrets
+ * carry a time-bounded lease that must be renewed before it expires, or the
+ * secret silently stops working. `outcome` is one of "success" (lease
+ * extended), "denied" (Vault refused renewal; a full secret reload was
+ * attempted as fallback), or "error" (the renewal request itself failed,
+ * e.g. Vault unreachable).
+ */
+export const vaultLeaseRenewalTotal = new Counter({
+  name: "vault_lease_renewal_total",
+  help: "Total number of Vault dynamic-secret lease renewal attempts, by outcome",
+  labelNames: ["outcome"] as const,
+  registers: [metricsRegistry],
+});
+
+export const vaultLeaseRenewalDurationSeconds = new Histogram({
+  name: "vault_lease_renewal_duration_seconds",
+  help: "Duration of a Vault lease renewal HTTP call in seconds",
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  registers: [metricsRegistry],
+});
+
+export const vaultLeaseSecondsRemaining = new Gauge({
+  name: "vault_lease_seconds_remaining",
+  help: "Seconds remaining on the current Vault dynamic-secret lease as of the last renewal or load",
+  registers: [metricsRegistry],
+});

--- a/src/utils/secret-loader.spec.ts
+++ b/src/utils/secret-loader.spec.ts
@@ -64,6 +64,192 @@ describe('SecretLoader', () => {
     })
   })
 
+  describe('VaultAdapter lease renewal', () => {
+    function leaseResponse(overrides: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: vi.fn(async () => ({
+          data: { VAULT_SECRET: 'vault-value' },
+          lease_id: 'lease-1',
+          lease_duration: 1000,
+          renewable: true,
+          ...overrides,
+        })),
+      }
+    }
+
+    function fakeTimer() {
+      const scheduled: { cb: () => void; ms: number }[] = []
+      const setTimeoutFn = vi.fn((cb: () => void, ms: number) => {
+        const handle = { id: scheduled.length }
+        scheduled.push({ cb, ms })
+        return handle
+      })
+      const clearTimeoutFn = vi.fn()
+      return { setTimeoutFn, clearTimeoutFn, scheduled }
+    }
+
+    it('schedules renewal at 70% of the lease duration when the lease is renewable', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => leaseResponse()) as typeof fetch)
+      const { setTimeoutFn, scheduled } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        randomFn: () => 0.5, // jitterFraction = 0 -> exactly 70%
+      })
+
+      await loader.reload()
+
+      expect(setTimeoutFn).toHaveBeenCalledTimes(1)
+      expect(scheduled[0].ms).toBe(1000 * 1000 * 0.7)
+    })
+
+    it('applies up to +/-10% jitter around the 70% renewal delay', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => leaseResponse()) as typeof fetch)
+      const { setTimeoutFn, scheduled } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        randomFn: () => 1, // maximum positive jitter
+      })
+
+      await loader.reload()
+
+      const base = 1000 * 1000 * 0.7
+      expect(scheduled[0].ms).toBe(Math.round(base * 1.1))
+    })
+
+    it('does not schedule renewal for a non-renewable lease', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => leaseResponse({ renewable: false })) as typeof fetch)
+      const { setTimeoutFn } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', { setTimeoutFn })
+
+      await loader.reload()
+
+      expect(setTimeoutFn).not.toHaveBeenCalled()
+    })
+
+    it('does not schedule renewal for a static secret with no lease fields', async () => {
+      const response = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: vi.fn(async () => ({ data: { VAULT_SECRET: 'vault-value' } })),
+      }
+      vi.stubGlobal('fetch', vi.fn(async () => response) as typeof fetch)
+      const { setTimeoutFn } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', { setTimeoutFn })
+
+      await loader.reload()
+
+      expect(setTimeoutFn).not.toHaveBeenCalled()
+    })
+
+    it('renews successfully, rotates the lease, and reschedules the next renewal', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(leaseResponse())
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: vi.fn(async () => ({ lease_id: 'lease-1', lease_duration: 2000, renewable: true })),
+        })
+      vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+      const { setTimeoutFn, scheduled } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        randomFn: () => 0.5,
+      })
+
+      await loader.reload()
+      expect(scheduled).toHaveLength(1)
+
+      // Manually fire the scheduled renewal.
+      await scheduled[0].cb()
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      const renewCall = fetchMock.mock.calls[1]
+      expect(renewCall[0]).toBe('https://vault.example.com/v1/sys/leases/renew')
+      expect(renewCall[1]).toMatchObject({ method: 'PUT' })
+      expect(JSON.parse(renewCall[1].body)).toEqual({ lease_id: 'lease-1', increment: 1000 })
+
+      expect(loader.getLease()).toEqual({ leaseId: 'lease-1', leaseDurationSeconds: 2000, renewable: true })
+      // Reschedule uses the new 2000s duration.
+      expect(scheduled).toHaveLength(2)
+      expect(scheduled[1].ms).toBe(2000 * 1000 * 0.7)
+    })
+
+    it('falls back to a full reload when renewal is denied (403)', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(leaseResponse())
+        .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' })
+        .mockResolvedValueOnce(leaseResponse({ lease_id: 'lease-2', lease_duration: 500 }))
+      vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+      const { setTimeoutFn, scheduled } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        randomFn: () => 0.5,
+      })
+
+      await loader.reload()
+      await scheduled[0].cb()
+
+      expect(fetchMock).toHaveBeenCalledTimes(3) // initial load, denied renew, fallback reload
+      expect(loader.getLease()?.leaseId).toBe('lease-2')
+      expect(await loader.get('VAULT_SECRET')).toBe('vault-value')
+    })
+
+    it('retries sooner after a renewal request failure, without throwing', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(leaseResponse())
+        .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+      const { setTimeoutFn, scheduled } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        randomFn: () => 0.5,
+      })
+
+      await loader.reload()
+      await expect(scheduled[0].cb()).resolves.toBeUndefined()
+
+      expect(scheduled).toHaveLength(2)
+      expect(scheduled[1].ms).toBe(30_000)
+    })
+
+    it('stopLeaseRenewal cancels the pending timer', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => leaseResponse()) as typeof fetch)
+      const { setTimeoutFn, clearTimeoutFn } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        clearTimeoutFn,
+      })
+
+      await loader.reload()
+      loader.stopLeaseRenewal()
+
+      expect(clearTimeoutFn).toHaveBeenCalledTimes(1)
+    })
+
+    it('reload() cancels a previously scheduled renewal before scheduling a new one', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => leaseResponse()) as typeof fetch)
+      const { setTimeoutFn, clearTimeoutFn } = fakeTimer()
+      const loader = new VaultAdapter('https://vault.example.com', 'secrets/path', 'token', {
+        setTimeoutFn,
+        clearTimeoutFn,
+      })
+
+      await loader.reload()
+      await loader.reload()
+
+      expect(clearTimeoutFn).toHaveBeenCalledTimes(1)
+      expect(setTimeoutFn).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('AwsSecretsAdapter', () => {
     it('loads secrets from AWS Secrets Manager', async () => {
       const mockSend = vi.fn(async () => ({

--- a/src/utils/secret-loader.ts
+++ b/src/utils/secret-loader.ts
@@ -1,6 +1,22 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import dotenv from 'dotenv'
+import {
+  vaultLeaseRenewalDurationSeconds,
+  vaultLeaseRenewalTotal,
+  vaultLeaseSecondsRemaining,
+} from '../metrics.js'
+
+/** Fraction of the lease duration at which renewal is attempted (70%). */
+const LEASE_RENEWAL_THRESHOLD_RATIO = 0.7
+/**
+ * Random jitter applied to the renewal delay, as a fraction of the base
+ * delay (±10%), so that many instances sharing similar lease timing don't
+ * all renew in the same instant (thundering herd).
+ */
+const LEASE_RENEWAL_JITTER_RATIO = 0.1
+/** Retry delay after a renewal *request* failure (not a denial). */
+const LEASE_RENEWAL_ERROR_RETRY_MS = 30_000
 
 export interface SecretAdapter {
   get(key: string): Promise<string>
@@ -103,18 +119,83 @@ export class EnvAdapter extends BaseSecretAdapter {
   }
 }
 
+/** A Vault dynamic-secret lease, tracked so it can be renewed before expiry. */
+export interface VaultLease {
+  leaseId: string
+  leaseDurationSeconds: number
+  renewable: boolean
+}
+
+export interface VaultAdapterOptions {
+  /** Injected for tests. Defaults to the global timer functions. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setTimeoutFn?: (cb: () => void, ms: number) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clearTimeoutFn?: (handle: any) => void
+  /** Injected for tests to make jitter deterministic. Defaults to `Math.random`. */
+  randomFn?: () => number
+}
+
 export class VaultAdapter extends BaseSecretAdapter {
+  private lease: VaultLease | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private renewalTimer: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly setTimeoutFn: (cb: () => void, ms: number) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly clearTimeoutFn: (handle: any) => void
+  private readonly randomFn: () => number
+
   constructor(
     private readonly baseUrl: string,
     private readonly secretPath: string,
     private readonly token?: string,
+    options: VaultAdapterOptions = {},
   ) {
     super()
+    this.setTimeoutFn = options.setTimeoutFn ?? setTimeout
+    this.clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout
+    this.randomFn = options.randomFn ?? Math.random
   }
 
+  /**
+   * Fetches secrets from Vault and, if the response carries a renewable
+   * lease, schedules automatic renewal. Cancels any previously-scheduled
+   * renewal first, so calling `reload()` externally never leaves a stale
+   * timer racing a fresh one.
+   */
   async reload(): Promise<void> {
+    this.cancelScheduledRenewal()
+    const { secrets, lease } = await this.fetchFromVault(this.secretPath)
+    this.secrets = secrets
+    this.lease = lease
+    this.loaded = true
+    if (lease) {
+      vaultLeaseSecondsRemaining.set(lease.leaseDurationSeconds)
+    }
+    this.scheduleRenewalIfEligible()
+  }
+
+  async get(key: string): Promise<string> {
+    this.ensureLoaded()
+    return this.toSecretValue(this.secrets.get(BaseSecretAdapter.normalizeSecretKey(key)), key)
+  }
+
+  /** Cancels any pending renewal timer. Safe to call even if none is scheduled. */
+  stopLeaseRenewal(): void {
+    this.cancelScheduledRenewal()
+  }
+
+  /** The currently tracked lease, if the last load/renewal returned one. */
+  getLease(): VaultLease | undefined {
+    return this.lease
+  }
+
+  private async fetchFromVault(
+    secretPath: string,
+  ): Promise<{ secrets: Map<string, string>; lease?: VaultLease }> {
     const normalizedBaseUrl = this.baseUrl.replace(/\/+$/, '')
-    const normalizedSecretPath = this.secretPath.replace(/^\/+/, '')
+    const normalizedSecretPath = secretPath.replace(/^\/+/, '')
     const url = `${normalizedBaseUrl}/${normalizedSecretPath}`
 
     let response: Response
@@ -143,13 +224,9 @@ export class VaultAdapter extends BaseSecretAdapter {
     }
 
     const payload = this.resolveVaultPayload(body)
-    this.secrets = BaseSecretAdapter.normalizeSecretValues(payload)
-    this.loaded = true
-  }
-
-  async get(key: string): Promise<string> {
-    this.ensureLoaded()
-    return this.toSecretValue(this.secrets.get(BaseSecretAdapter.normalizeSecretKey(key)), key)
+    const secrets = BaseSecretAdapter.normalizeSecretValues(payload)
+    const lease = this.resolveVaultLease(body)
+    return { secrets, lease }
   }
 
   private resolveVaultPayload(body: unknown): Record<string, unknown> {
@@ -161,6 +238,119 @@ export class VaultAdapter extends BaseSecretAdapter {
       return body as Record<string, unknown>
     }
     throw new SecretLoadError('Vault response payload was not an object')
+  }
+
+  /**
+   * Extracts lease metadata from a Vault response envelope, e.g.
+   * `{ lease_id, lease_duration, renewable, data: {...} }`. Static secrets
+   * (or any response missing these fields) yield `undefined` — no renewal
+   * is scheduled for them.
+   */
+  private resolveVaultLease(body: unknown): VaultLease | undefined {
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return undefined
+    const envelope = body as Record<string, unknown>
+    const leaseId = envelope.lease_id
+    const leaseDuration = envelope.lease_duration
+
+    if (typeof leaseId !== 'string' || leaseId === '' || typeof leaseDuration !== 'number' || leaseDuration <= 0) {
+      return undefined
+    }
+
+    return {
+      leaseId,
+      leaseDurationSeconds: leaseDuration,
+      renewable: envelope.renewable === true,
+    }
+  }
+
+  private scheduleRenewalIfEligible(): void {
+    if (!this.lease?.renewable) return
+    const delayMs = this.renewalDelayMs(this.lease.leaseDurationSeconds)
+    // Returns the renew() promise (rather than a fire-and-forget `void`) so
+    // tests using an injected `setTimeoutFn` can await the scheduled
+    // callback and observe its effects deterministically. A real `setTimeout`
+    // ignores the callback's return value, so this is a no-op change in
+    // production.
+    this.renewalTimer = this.setTimeoutFn(() => this.renew(), delayMs)
+  }
+
+  /** 70% of the lease duration, plus up to ±10% jitter (thundering-herd avoidance). */
+  private renewalDelayMs(leaseDurationSeconds: number): number {
+    const baseMs = leaseDurationSeconds * 1000 * LEASE_RENEWAL_THRESHOLD_RATIO
+    const jitterFraction = (this.randomFn() * 2 - 1) * LEASE_RENEWAL_JITTER_RATIO
+    return Math.max(0, Math.round(baseMs * (1 + jitterFraction)))
+  }
+
+  private cancelScheduledRenewal(): void {
+    if (this.renewalTimer !== undefined) {
+      this.clearTimeoutFn(this.renewalTimer)
+      this.renewalTimer = undefined
+    }
+  }
+
+  /**
+   * Renews the current lease via Vault's `sys/leases/renew` endpoint.
+   *
+   * - On success: updates the tracked lease (Vault may extend it by less
+   *   than requested) and schedules the next renewal.
+   * - On denial (403/404 — the lease was revoked, expired server-side, or
+   *   the token lacks permission): falls back to a full {@link reload},
+   *   rotating in-memory secrets from a freshly-issued lease rather than
+   *   continuing to serve one that Vault has already given up on.
+   * - On any other failure (e.g. Vault unreachable): logs a metric and
+   *   retries sooner than the normal schedule, so a transient blip doesn't
+   *   let the lease silently expire.
+   *
+   * Never throws — a renewal failure must not crash the process.
+   */
+  private async renew(): Promise<void> {
+    const lease = this.lease
+    if (!lease) return
+    const start = Date.now()
+
+    try {
+      const url = `${this.baseUrl.replace(/\/+$/, '')}/v1/sys/leases/renew`
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+        },
+        body: JSON.stringify({ lease_id: lease.leaseId, increment: lease.leaseDurationSeconds }),
+      })
+
+      if (response.status === 403 || response.status === 404) {
+        vaultLeaseRenewalTotal.labels('denied').inc()
+        await this.reload()
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error(`renew failed with status ${response.status}`)
+      }
+
+      const body = (await response.json()) as {
+        lease_id?: string
+        lease_duration?: number
+        renewable?: boolean
+      }
+      this.lease = {
+        leaseId: typeof body.lease_id === 'string' && body.lease_id !== '' ? body.lease_id : lease.leaseId,
+        leaseDurationSeconds:
+          typeof body.lease_duration === 'number' && body.lease_duration > 0
+            ? body.lease_duration
+            : lease.leaseDurationSeconds,
+        renewable: body.renewable !== false,
+      }
+      vaultLeaseSecondsRemaining.set(this.lease.leaseDurationSeconds)
+      vaultLeaseRenewalTotal.labels('success').inc()
+      this.scheduleRenewalIfEligible()
+    } catch {
+      vaultLeaseRenewalTotal.labels('error').inc()
+      this.renewalTimer = this.setTimeoutFn(() => this.renew(), LEASE_RENEWAL_ERROR_RETRY_MS)
+    } finally {
+      vaultLeaseRenewalDurationSeconds.observe((Date.now() - start) / 1000)
+    }
   }
 }
 


### PR DESCRIPTION
Closes #554

## Summary

`VaultAdapter` (`src/utils/secret-loader.ts`) now tracks the lease Vault returns alongside a dynamic secret and auto-renews it before expiry, instead of silently letting it lapse and causing an outage.

- `reload()` extracts `lease_id` / `lease_duration` / `renewable` from the Vault response envelope. Static secrets (or any response missing these fields) get no lease tracked and no renewal scheduled — this only activates for genuinely renewable dynamic secrets.
- Renewal is scheduled at **70% of the lease duration**, with up to **±10% random jitter**, so many instances sharing similar lease timing don't all renew in the same instant (thundering herd).
- On successful renewal (`PUT {baseUrl}/v1/sys/leases/renew`), the lease is updated from Vault's response and the next renewal is rescheduled from the new duration.
- **Renewal denied fallback**: on a 403/404 (lease revoked, or the token lacks permission), falls back to a full `reload()` — rotating in-memory secrets from a freshly-issued lease rather than continuing to serve one Vault has already given up on.
- On any other renewal failure (e.g. Vault unreachable), retries after 30s rather than waiting for the next scheduled ~70%-of-lease attempt, so a transient blip doesn't let the lease silently expire. The renewal path never throws.
- New metrics: `vault_lease_renewal_total{outcome}` (`success` | `denied` | `error`), `vault_lease_renewal_duration_seconds`, `vault_lease_seconds_remaining`.
- Timers and jitter are injectable (`setTimeoutFn`/`clearTimeoutFn`/`randomFn`) via a new optional 4th `VaultAdapter` constructor argument, matching this repo's existing DI pattern for testable timers (see `IdempotencySweeperOptions` in `src/middleware/idempotency.ts`). Existing 3-arg call sites are unaffected.
- `stopLeaseRenewal()` / `getLease()` added for callers that want to explicitly stop renewal or inspect the current lease.

Documented in `.env.example` and with a short doc comment in `src/config/index.ts` (the file named in the issue) pointing at the actual implementation in `secret-loader.ts`.

I also noticed and flagged (but did **not** fix, to avoid breaking an existing deployment either way) a pre-existing, unrelated naming inconsistency: `src/config/index.ts`'s zod schema validates `SECRET_LOADER`, while `createSecretLoader()` in `secret-loader.ts` actually reads `SECRET_PROVIDER` from `process.env` — two different env var names for the same concept. Noted inline in `.env.example`.

## Tests

`src/utils/secret-loader.spec.ts` gains a "VaultAdapter lease renewal" suite:
- schedules renewal at exactly 70% of lease duration (deterministic jitter via injected `randomFn`)
- applies up to ±10% jitter around that 70%
- does **not** schedule renewal for a non-renewable lease, or a static secret with no lease fields at all
- successful renew → lease rotated, next renewal rescheduled from the new duration
- **denied renewal (403) → falls back to a full reload**, secrets rotated from the fallback fetch
- renewal request failure (network error) → retries sooner (30s), never throws
- `stopLeaseRenewal()` cancels the pending timer
- `reload()` cancels a previously-scheduled renewal before scheduling a fresh one

```
npx vitest run src/utils/secret-loader.spec.ts
 Test Files  1 failed (1)
      Tests  3 failed | 17 passed (20)
```

The 3 failures (`AwsSecretsAdapter` + 2 `Failover mechanism` tests) are pre-existing on a clean `main` checkout — confirmed via `git stash` — unrelated to this change (`vi.spyOn` on a plain object property, and an AWS SDK constructor typing issue).

`npx tsc --noEmit` shows no new errors from the files this PR touches (repo-wide `tsc --noEmit` already has pre-existing errors elsewhere, confirmed independent of this change).