### PR TITLE
feat: guard migrations with lock_timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/veritasor
 # Reject invalid server certificates when SSL is enabled
 # PGSSL_REJECT_UNAUTHORIZED=true
 
+# Migration runner timeouts (SET LOCAL inside each migration transaction).
+# Fail fast on lock waits so DDL cannot stall application traffic.
+# MIGRATION_LOCK_TIMEOUT_MS=5000
+# Abort a single migration statement after this budget (0 disables).
+# MIGRATION_STATEMENT_TIMEOUT_MS=60000
+
 # ------------------------------------------------------------------------------
 # Redis (Rate Limiting & Idempotency)
 # ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -229,6 +229,20 @@ DATABASE_URL=postgresql://user:pass@localhost:5432/dbname npx tsx src/db/migrate
 
 Requires Node 18+ and a running PostgreSQL instance.
 
+### Migration lock / statement timeouts
+
+Each migration transaction sets `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` so long-running DDL cannot hold locks and stall traffic. Defaults: **5s** lock wait (`MIGRATION_LOCK_TIMEOUT_MS`) and **60s** statement budget (`MIGRATION_STATEMENT_TIMEOUT_MS`). On breach the runner rolls back, emits a `migration_timeout_breach` audit event, and throws `MigrationTimeoutError`.
+
+Per-file overrides (leading SQL comments):
+
+```sql
+-- @lock_timeout_ms 5000
+-- @statement_timeout_ms 0
+CREATE INDEX idx_big ON large_table (col);
+```
+
+Use `statement_timeout_ms 0` (or a higher value) for long index builds while keeping a tight lock timeout. Full details: [docs/migration-timeouts.md](docs/migration-timeouts.md).
+
 ## Environment
 
 Optional `.env`:
@@ -236,6 +250,8 @@ Optional `.env`:
 ```
 PORT=3000
 DATABASE_URL=postgresql://user:password@localhost:5432/veritasor
+# MIGRATION_LOCK_TIMEOUT_MS=5000
+# MIGRATION_STATEMENT_TIMEOUT_MS=60000
 ```
 
 ## Merging to remote

--- a/docs/migration-timeouts.md
+++ b/docs/migration-timeouts.md
@@ -1,0 +1,97 @@
+# Migration lock / statement timeout guard
+
+Long-running DDL can hold locks and stall application traffic. The migration
+runner in `src/db/migrate.ts` therefore sets **`lock_timeout`** and
+**`statement_timeout`** for every up/down migration transaction and **fails
+fast** when either limit is breached.
+
+## Defaults
+
+| Setting | Env var | Default |
+|---|---|---|
+| Lock wait | `MIGRATION_LOCK_TIMEOUT_MS` | `5000` (5s) |
+| Statement | `MIGRATION_STATEMENT_TIMEOUT_MS` | `60000` (60s) |
+
+Both are applied with `SET LOCAL` inside the migration transaction so they do
+not leak to other sessions (including via PgBouncer transaction pooling).
+
+`0` disables the corresponding timeout (PostgreSQL semantics).
+
+## Fail-fast + audit
+
+On breach the runner:
+
+1. `ROLLBACK`s the migration transaction (nothing is recorded in `schema_migrations`).
+2. Emits a structured audit event `migration_timeout_breach` via `logger.error`
+   (or an injected `onAudit` sink in tests / automation).
+3. Throws `MigrationTimeoutError` (`code: MIGRATION_TIMEOUT`) with
+   `breach: 'lock_timeout' | 'statement_timeout'`.
+
+PostgreSQL codes mapped:
+
+| PG code | Meaning | Breach |
+|---|---|---|
+| `55P03` | `lock_not_available` | `lock_timeout` |
+| `57014` | `query_canceled` (statement timeout) | `statement_timeout` |
+
+Audit payload fields: `event`, `version`, `direction` (`up`|`down`), `breach`,
+`lockTimeoutMs`, `statementTimeoutMs`, optional `pgCode`, `message`, `timestamp`.
+
+## Per-migration overrides
+
+Place directives in **leading** SQL comments (before the first non-comment line):
+
+```sql
+-- @lock_timeout_ms 5000
+-- @statement_timeout_ms 0
+CREATE INDEX idx_events_created_at ON events (created_at);
+```
+
+Alternate forms accepted: `@lock_timeout 5s`, `@statement_timeout: 10m`.
+Bare integers are milliseconds; suffixes `ms` / `s` / `m` are supported.
+
+### Long index builds
+
+Index builds that need more than the default statement budget should raise or
+disable `statement_timeout` while keeping a tight `lock_timeout` so lock waits
+still fail fast:
+
+```sql
+-- @lock_timeout_ms 5000
+-- @statement_timeout_ms 0
+CREATE INDEX idx_big ON large_table (col);
+```
+
+> Note: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. This runner
+> always wraps migrations in `BEGIN`/`COMMIT`, so use a normal `CREATE INDEX`
+> with an elevated `statement_timeout` instead.
+
+## Security notes
+
+- Timeout values are validated as non-negative integers within
+  `[0, 86400000]` before interpolation into `SET LOCAL`. Raw strings from SQL
+  headers or env are never concatenated into SQL.
+- Unrelated SQL errors still roll back and do **not** emit a timeout audit event.
+- Defaults favour short lock waits so a blocked migration cannot hold the
+  deploy pipeline / connection while traffic queues behind an AccessExclusiveLock.
+
+## Run-level options (programmatic)
+
+```ts
+await runMigrations(client, migrationsDir, {
+  timeouts: { lockTimeoutMs: 1500, statementTimeoutMs: 45_000 },
+  onAudit: (record) => mySink(record),
+})
+```
+
+File-level directives override run-level / env values for that migration only.
+
+## Testing
+
+```bash
+npx vitest run tests/db/migrate.test.ts
+```
+
+Coverage includes default application order (`BEGIN` → `SET LOCAL` → DDL),
+lock/statement breach fail-fast + audit, long-index override (`statement_timeout=0`),
+rollback path parity, and rejection of unsafe override values.

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -2,6 +2,12 @@
  * Migration runner: applies pending SQL migrations and supports rollback.
  * Tracks applied migrations in schema_migrations so each runs once.
  *
+ * Timeout guard (issue #571):
+ *   Each migration runs inside a transaction with SET LOCAL lock_timeout and
+ *   statement_timeout so long-running DDL cannot hold locks and stall traffic.
+ *   Defaults are env-tunable; individual SQL files may override via header
+ *   comments. Timeout breaches fail fast and emit a structured audit event.
+ *
  * Usage:
  *   npm run migrate              – apply all pending migrations
  *   npm run migrate:rollback     – roll back the last 1 migration
@@ -10,15 +16,105 @@
  * File conventions (both supported):
  *   Legacy:  001_foo.sql          → up-only, no rollback available
  *   Paired:  001_foo.up.sql  +  001_foo.down.sql  → supports rollback
+ *
+ * Per-migration timeout overrides (optional leading SQL comments):
+ *   -- @lock_timeout_ms 5000
+ *   -- @statement_timeout_ms 0
+ *   Durations may also use units: 5s, 2m, 500ms. `0` disables that timeout
+ *   (e.g. long index builds that need a raised/disabled statement_timeout
+ *   while keeping a tight lock_timeout).
  */
 
 import pg from 'pg'
 import { readdir, readFile, access } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { logger } from '../utils/logger.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 export const MIGRATIONS_DIR = join(__dirname, 'migrations')
+
+/** Default: fail fast if a lock cannot be acquired within 5 seconds. */
+export const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 5_000
+
+/**
+ * Default: abort a single migration statement after 60 seconds.
+ * Override per file (e.g. `@statement_timeout_ms 0`) for long index builds.
+ */
+export const DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS = 60_000
+
+/** Hard ceiling to reject absurd / injection-prone override values. */
+export const MAX_MIGRATION_TIMEOUT_MS = 24 * 60 * 60 * 1000
+
+/** PostgreSQL: lock_not_available (lock_timeout). */
+export const PG_LOCK_NOT_AVAILABLE = '55P03'
+
+/** PostgreSQL: query_canceled (statement_timeout / cancel). */
+export const PG_QUERY_CANCELED = '57014'
+
+export type MigrationTimeouts = {
+  lockTimeoutMs: number
+  statementTimeoutMs: number
+}
+
+export type MigrationTimeoutBreach = 'lock_timeout' | 'statement_timeout'
+
+export type MigrationDirection = 'up' | 'down'
+
+export type MigrationTimeoutAuditRecord = {
+  event: 'migration_timeout_breach'
+  version: string
+  direction: MigrationDirection
+  breach: MigrationTimeoutBreach
+  lockTimeoutMs: number
+  statementTimeoutMs: number
+  pgCode?: string
+  message: string
+  timestamp: string
+}
+
+export type MigrationAuditLogger = (record: MigrationTimeoutAuditRecord) => void
+
+export type RunMigrationOptions = {
+  /** Global timeout overrides for this run (still overridable per SQL file). */
+  timeouts?: Partial<MigrationTimeouts>
+  /** Optional audit sink; defaults to structured logger.error. */
+  onAudit?: MigrationAuditLogger
+}
+
+export class MigrationTimeoutError extends Error {
+  readonly code = 'MIGRATION_TIMEOUT'
+  readonly breach: MigrationTimeoutBreach
+  readonly version: string
+  readonly direction: MigrationDirection
+  readonly timeouts: MigrationTimeouts
+  readonly pgCode?: string
+
+  constructor(params: {
+    version: string
+    direction: MigrationDirection
+    breach: MigrationTimeoutBreach
+    timeouts: MigrationTimeouts
+    pgCode?: string
+    cause?: Error
+  }) {
+    const { version, direction, breach, timeouts, pgCode, cause } = params
+    super(
+      `Migration "${version}" (${direction}) aborted: ${breach} breached ` +
+        `(lock_timeout=${timeouts.lockTimeoutMs}ms, statement_timeout=${timeouts.statementTimeoutMs}ms)` +
+        (pgCode ? ` [pg=${pgCode}]` : '')
+    )
+    this.name = 'MigrationTimeoutError'
+    this.breach = breach
+    this.version = version
+    this.direction = direction
+    this.timeouts = { ...timeouts }
+    this.pgCode = pgCode
+    if (cause) {
+      ;(this as Error & { cause?: Error }).cause = cause
+    }
+  }
+}
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -74,9 +170,251 @@ export async function getDownSql(version: string, dir: string = MIGRATIONS_DIR):
   }
 }
 
+/**
+ * Parse a duration string into milliseconds.
+ * Accepts bare integers (ms) or values with units: ms, s, m.
+ */
+export function parseDurationMs(raw: string): number {
+  const trimmed = raw.trim().toLowerCase()
+  if (!trimmed) {
+    throw new Error('Duration must not be empty')
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10)
+  }
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)(ms|s|m)$/)
+  if (!match) {
+    throw new Error(
+      `Invalid duration "${raw}": use milliseconds (e.g. 5000) or a unit suffix (5s, 2m, 500ms)`
+    )
+  }
+  const value = Number(match[1])
+  const unit = match[2]
+  if (unit === 'ms') return Math.round(value)
+  if (unit === 's') return Math.round(value * 1_000)
+  return Math.round(value * 60_000)
+}
+
+/**
+ * Assert a timeout value is a safe non-negative integer within the hard ceiling.
+ * Values are interpolated into SET LOCAL; rejecting non-integers prevents injection.
+ */
+export function assertSafeTimeoutMs(value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_MIGRATION_TIMEOUT_MS) {
+    throw new Error(
+      `Invalid ${label}: must be an integer in [0, ${MAX_MIGRATION_TIMEOUT_MS}] ms; got ${String(value)}`
+    )
+  }
+  return value
+}
+
+function readEnvTimeoutMs(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  fallback: number
+): number {
+  const raw = env[key]
+  if (raw == null || raw === '') return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${key} must be a non-negative integer (milliseconds); got "${raw}"`)
+  }
+  return assertSafeTimeoutMs(parsed, key)
+}
+
+/**
+ * Resolve effective timeouts: defaults ← env ← run options ← per-file overrides.
+ */
+export function resolveMigrationTimeouts(
+  overrides: Partial<MigrationTimeouts> = {},
+  env: NodeJS.ProcessEnv = process.env
+): MigrationTimeouts {
+  const lockTimeoutMs = assertSafeTimeoutMs(
+    overrides.lockTimeoutMs ??
+      readEnvTimeoutMs(env, 'MIGRATION_LOCK_TIMEOUT_MS', DEFAULT_MIGRATION_LOCK_TIMEOUT_MS),
+    'lock_timeout'
+  )
+  const statementTimeoutMs = assertSafeTimeoutMs(
+    overrides.statementTimeoutMs ??
+      readEnvTimeoutMs(
+        env,
+        'MIGRATION_STATEMENT_TIMEOUT_MS',
+        DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS
+      ),
+    'statement_timeout'
+  )
+  return { lockTimeoutMs, statementTimeoutMs }
+}
+
+/**
+ * Parse optional `@lock_timeout_ms` / `@statement_timeout_ms` directives from
+ * leading SQL comment lines. Stops at the first non-comment, non-blank line.
+ */
+export function parseMigrationTimeoutOverrides(sql: string): Partial<MigrationTimeouts> {
+  const overrides: Partial<MigrationTimeouts> = {}
+
+  for (const line of sql.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (!trimmed.startsWith('--')) break
+
+    const lockMatch = trimmed.match(
+      /^--\s*@lock_timeout(?:_ms)?\s*[:=]?\s*(.+?)\s*$/i
+    )
+    if (lockMatch) {
+      overrides.lockTimeoutMs = assertSafeTimeoutMs(
+        parseDurationMs(lockMatch[1]),
+        'lock_timeout override'
+      )
+      continue
+    }
+
+    const statementMatch = trimmed.match(
+      /^--\s*@statement_timeout(?:_ms)?\s*[:=]?\s*(.+?)\s*$/i
+    )
+    if (statementMatch) {
+      overrides.statementTimeoutMs = assertSafeTimeoutMs(
+        parseDurationMs(statementMatch[1]),
+        'statement_timeout override'
+      )
+    }
+  }
+
+  return overrides
+}
+
+/**
+ * Apply SET LOCAL lock_timeout / statement_timeout for the current transaction.
+ * Values are validated integers only — never raw user strings.
+ */
+export async function applyMigrationTimeouts(
+  client: Pick<pg.Client, 'query'>,
+  timeouts: MigrationTimeouts
+): Promise<void> {
+  const lockMs = assertSafeTimeoutMs(timeouts.lockTimeoutMs, 'lock_timeout')
+  const statementMs = assertSafeTimeoutMs(timeouts.statementTimeoutMs, 'statement_timeout')
+  await client.query(`SET LOCAL lock_timeout = ${lockMs}`)
+  await client.query(`SET LOCAL statement_timeout = ${statementMs}`)
+}
+
+/**
+ * Classify a PostgreSQL (or simulated) error as a timeout breach, or null.
+ */
+export function classifyTimeoutBreach(err: unknown): MigrationTimeoutBreach | null {
+  const e = err as { code?: string; message?: string } | null | undefined
+  if (!e) return null
+
+  if (e.code === PG_LOCK_NOT_AVAILABLE) return 'lock_timeout'
+  if (e.code === PG_QUERY_CANCELED) {
+    const msg = (e.message ?? '').toLowerCase()
+    // Prefer explicit statement-timeout wording; otherwise treat cancel as statement.
+    if (msg.includes('lock') && msg.includes('timeout')) return 'lock_timeout'
+    return 'statement_timeout'
+  }
+
+  const msg = (e.message ?? '').toLowerCase()
+  if (msg.includes('lock_not_available') || /\block timeout\b/.test(msg)) {
+    return 'lock_timeout'
+  }
+  if (msg.includes('statement timeout') || msg.includes('canceling statement due to statement timeout')) {
+    return 'statement_timeout'
+  }
+  return null
+}
+
+export function emitMigrationTimeoutAudit(
+  record: Omit<MigrationTimeoutAuditRecord, 'event' | 'timestamp'> & {
+    timestamp?: string
+  },
+  onAudit: MigrationAuditLogger = defaultMigrationAuditLogger
+): MigrationTimeoutAuditRecord {
+  const full: MigrationTimeoutAuditRecord = {
+    event: 'migration_timeout_breach',
+    timestamp: record.timestamp ?? new Date().toISOString(),
+    version: record.version,
+    direction: record.direction,
+    breach: record.breach,
+    lockTimeoutMs: record.lockTimeoutMs,
+    statementTimeoutMs: record.statementTimeoutMs,
+    pgCode: record.pgCode,
+    message: record.message,
+  }
+  onAudit(full)
+  return full
+}
+
+const defaultMigrationAuditLogger: MigrationAuditLogger = (record) => {
+  logger.error(record)
+}
+
+function mergeTimeouts(
+  runOverrides: Partial<MigrationTimeouts> | undefined,
+  fileSql: string,
+  env: NodeJS.ProcessEnv = process.env
+): MigrationTimeouts {
+  const fileOverrides = parseMigrationTimeoutOverrides(fileSql)
+  return resolveMigrationTimeouts({ ...runOverrides, ...fileOverrides }, env)
+}
+
+async function runMigrationSql(
+  client: Pick<pg.Client, 'query'>,
+  version: string,
+  direction: MigrationDirection,
+  sql: string,
+  options: RunMigrationOptions
+): Promise<void> {
+  const timeouts = mergeTimeouts(options.timeouts, sql)
+  await client.query('BEGIN')
+  try {
+    await applyMigrationTimeouts(client, timeouts)
+    await client.query(sql)
+    if (direction === 'up') {
+      await client.query('INSERT INTO schema_migrations (version) VALUES ($1)', [version])
+    } else {
+      await client.query('DELETE FROM schema_migrations WHERE version = $1', [version])
+    }
+    await client.query('COMMIT')
+    console.log(direction === 'up' ? `Applied: ${version}` : `Rolled back: ${version}`)
+  } catch (err) {
+    await client.query('ROLLBACK')
+    const breach = classifyTimeoutBreach(err)
+    if (breach) {
+      const pgCode = (err as { code?: string }).code
+      const message = (err as Error).message ?? String(err)
+      emitMigrationTimeoutAudit(
+        {
+          version,
+          direction,
+          breach,
+          lockTimeoutMs: timeouts.lockTimeoutMs,
+          statementTimeoutMs: timeouts.statementTimeoutMs,
+          pgCode,
+          message,
+        },
+        options.onAudit
+      )
+      throw new MigrationTimeoutError({
+        version,
+        direction,
+        breach,
+        timeouts,
+        pgCode,
+        cause: err instanceof Error ? err : undefined,
+      })
+    }
+    throw new Error(
+      `${direction === 'up' ? 'Migration' : 'Rollback'} failed for "${version}": ${(err as Error).message}`
+    )
+  }
+}
+
 // ─── core logic ─────────────────────────────────────────────────────────────
 
-export async function runMigrations(client: pg.Client, dir: string = MIGRATIONS_DIR): Promise<void> {
+export async function runMigrations(
+  client: Pick<pg.Client, 'query'>,
+  dir: string = MIGRATIONS_DIR,
+  options: RunMigrationOptions = {}
+): Promise<void> {
   await client.query(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       version TEXT PRIMARY KEY,
@@ -99,23 +437,15 @@ export async function runMigrations(client: pg.Client, dir: string = MIGRATIONS_
 
   for (const version of pending) {
     const sql = await getUpSql(version, dir)
-    await client.query('BEGIN')
-    try {
-      await client.query(sql)
-      await client.query('INSERT INTO schema_migrations (version) VALUES ($1)', [version])
-      await client.query('COMMIT')
-      console.log(`Applied: ${version}`)
-    } catch (err) {
-      await client.query('ROLLBACK')
-      throw new Error(`Migration failed for "${version}": ${(err as Error).message}`)
-    }
+    await runMigrationSql(client, version, 'up', sql, options)
   }
 }
 
 export async function runRollback(
-  client: pg.Client,
+  client: Pick<pg.Client, 'query'>,
   steps: number = 1,
-  dir: string = MIGRATIONS_DIR
+  dir: string = MIGRATIONS_DIR,
+  options: RunMigrationOptions = {}
 ): Promise<void> {
   await client.query(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -124,10 +454,10 @@ export async function runRollback(
     )
   `)
 
-  const { rows } = await client.query<{ version: string }>(
+  const { rows } = await client.query(
     'SELECT version FROM schema_migrations ORDER BY version DESC LIMIT $1',
     [steps]
-  )
+  ) as { rows: { version: string }[] }
 
   if (rows.length === 0) {
     console.log('Nothing to roll back.')
@@ -141,32 +471,41 @@ export async function runRollback(
 
   for (const { version } of rows) {
     const sql = await getDownSql(version, dir)
-    await client.query('BEGIN')
-    try {
-      await client.query(sql)
-      await client.query('DELETE FROM schema_migrations WHERE version = $1', [version])
-      await client.query('COMMIT')
-      console.log(`Rolled back: ${version}`)
-    } catch (err) {
-      await client.query('ROLLBACK')
-      throw new Error(`Rollback failed for "${version}": ${(err as Error).message}`)
-    }
+    await runMigrationSql(client, version, 'down', sql, options)
   }
 }
 
 // ─── CLI entry point ─────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
-  const connectionString = process.env.DATABASE_URL
+/** True when this module is the process entrypoint (not imported by tests). */
+export function isMigrateCliEntrypoint(
+  argv1: string | undefined,
+  moduleUrl: string
+): boolean {
+  return Boolean(argv1 && fileURLToPath(moduleUrl) === argv1)
+}
+
+/**
+ * CLI driver for `npm run migrate` / `migrate:rollback`.
+ * Exported for unit tests; production entry uses {@link isMigrateCliEntrypoint}.
+ */
+export async function runMigrateCli(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: string[] = process.argv,
+  exitFn: (code: number) => never = ((code) => process.exit(code)) as (code: number) => never,
+  ClientCtor: typeof pg.Client = pg.Client
+): Promise<void> {
+  const connectionString = env.DATABASE_URL
   if (!connectionString) {
     console.error('DATABASE_URL is required.')
-    process.exit(1)
+    exitFn(1)
+    return
   }
 
-  const command = process.argv[2]   // 'rollback' or undefined
-  const steps   = parseInt(process.argv[3] ?? '1', 10)
+  const command = argv[2]   // 'rollback' or undefined
+  const steps   = parseInt(argv[3] ?? '1', 10)
 
-  const client = new pg.Client({ connectionString })
+  const client = new ClientCtor({ connectionString })
   try {
     await client.connect()
     if (command === 'rollback') {
@@ -179,10 +518,15 @@ async function main(): Promise<void> {
   }
 }
 
+export async function handleMigrateCliFailure(
+  err: unknown,
+  exitFn: (code: number) => never = ((code) => process.exit(code)) as (code: number) => never
+): Promise<never> {
+  console.error('Fatal:', err instanceof Error ? err.message : String(err))
+  exitFn(1)
+}
+
 // Only run when executed directly (not when imported in tests)
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  main().catch((err) => {
-    console.error('Fatal:', err.message)
-    process.exit(1)
-  })
+if (isMigrateCliEntrypoint(process.argv[1], import.meta.url)) {
+  runMigrateCli().catch(handleMigrateCliFailure)
 }

--- a/tests/db/migrate.test.ts
+++ b/tests/db/migrate.test.ts
@@ -1,9 +1,11 @@
 /**
  * Tests for src/db/migrate.ts
- * Covers: discoverMigrations, getUpSql, getDownSql, runMigrations, runRollback
+ * Covers: discoverMigrations, getUpSql, getDownSql, runMigrations, runRollback,
+ *         timeout guards (lock_timeout / statement_timeout), overrides, audit.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fileURLToPath } from 'node:url'
 
 // ─── Mock node:fs/promises before importing the module ───────────────────────
 vi.mock('node:fs/promises', () => ({
@@ -12,7 +14,16 @@ vi.mock('node:fs/promises', () => ({
   access:  vi.fn(),
 }))
 
+vi.mock('../../src/utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
 import * as fsp from 'node:fs/promises'
+import { logger } from '../../src/utils/logger.js'
 import {
   discoverMigrations,
   getUpSql,
@@ -20,6 +31,19 @@ import {
   runMigrations,
   runRollback,
   MIGRATIONS_DIR,
+  parseDurationMs,
+  parseMigrationTimeoutOverrides,
+  resolveMigrationTimeouts,
+  assertSafeTimeoutMs,
+  applyMigrationTimeouts,
+  classifyTimeoutBreach,
+  emitMigrationTimeoutAudit,
+  MigrationTimeoutError,
+  DEFAULT_MIGRATION_LOCK_TIMEOUT_MS,
+  DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS,
+  MAX_MIGRATION_TIMEOUT_MS,
+  PG_LOCK_NOT_AVAILABLE,
+  PG_QUERY_CANCELED,
 } from '../../src/db/migrate'
 
 const mockReaddir = fsp.readdir  as ReturnType<typeof vi.fn>
@@ -51,6 +75,14 @@ function withQueryImpl(
     client.calls.push(sql.trim())
     return impl(sql, params)
   })
+}
+
+function stubLegacyMigration(sql = 'CREATE TABLE x();') {
+  mockReaddir.mockResolvedValue(['001_users.sql'])
+  mockAccess
+    .mockRejectedValueOnce(new Error()) // .up.sql missing
+    .mockResolvedValueOnce(undefined)   // legacy .sql exists
+  mockReadFile.mockResolvedValue(sql)
 }
 
 // ─── discoverMigrations ───────────────────────────────────────────────────────
@@ -136,6 +168,207 @@ describe('getDownSql', () => {
   })
 })
 
+// ─── timeout helpers ─────────────────────────────────────────────────────────
+describe('parseDurationMs', () => {
+  it('parses bare milliseconds', () => {
+    expect(parseDurationMs('5000')).toBe(5000)
+  })
+
+  it('parses unit suffixes', () => {
+    expect(parseDurationMs('5s')).toBe(5_000)
+    expect(parseDurationMs('2m')).toBe(120_000)
+    expect(parseDurationMs('500ms')).toBe(500)
+    expect(parseDurationMs('1.5s')).toBe(1_500)
+  })
+
+  it('rejects empty and malformed values', () => {
+    expect(() => parseDurationMs('')).toThrow(/empty/)
+    expect(() => parseDurationMs('5 hours')).toThrow(/Invalid duration/)
+    expect(() => parseDurationMs('abc')).toThrow(/Invalid duration/)
+  })
+})
+
+describe('assertSafeTimeoutMs', () => {
+  it('accepts zero and positive integers within the ceiling', () => {
+    expect(assertSafeTimeoutMs(0, 'x')).toBe(0)
+    expect(assertSafeTimeoutMs(MAX_MIGRATION_TIMEOUT_MS, 'x')).toBe(MAX_MIGRATION_TIMEOUT_MS)
+  })
+
+  it('rejects negatives, floats, and values above the ceiling', () => {
+    expect(() => assertSafeTimeoutMs(-1, 'x')).toThrow(/Invalid x/)
+    expect(() => assertSafeTimeoutMs(1.5, 'x')).toThrow(/Invalid x/)
+    expect(() => assertSafeTimeoutMs(MAX_MIGRATION_TIMEOUT_MS + 1, 'x')).toThrow(/Invalid x/)
+  })
+})
+
+describe('parseMigrationTimeoutOverrides', () => {
+  it('parses leading @lock_timeout_ms and @statement_timeout_ms comments', () => {
+    const sql = `
+-- @lock_timeout_ms 3000
+-- @statement_timeout_ms 0
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx ON t(id);
+`.trim()
+    expect(parseMigrationTimeoutOverrides(sql)).toEqual({
+      lockTimeoutMs: 3000,
+      statementTimeoutMs: 0,
+    })
+  })
+
+  it('accepts unit suffixes and alternate directive names', () => {
+    const sql = `
+-- @lock_timeout 5s
+-- @statement_timeout: 10m
+ALTER TABLE t ADD COLUMN x int;
+`.trim()
+    expect(parseMigrationTimeoutOverrides(sql)).toEqual({
+      lockTimeoutMs: 5_000,
+      statementTimeoutMs: 600_000,
+    })
+  })
+
+  it('stops at the first non-comment line (ignores mid-file comments)', () => {
+    const sql = `
+CREATE TABLE t(id int);
+-- @lock_timeout_ms 1
+`.trim()
+    expect(parseMigrationTimeoutOverrides(sql)).toEqual({})
+  })
+
+  it('rejects unsafe override values', () => {
+    expect(() =>
+      parseMigrationTimeoutOverrides('-- @lock_timeout_ms -5\nSELECT 1;')
+    ).toThrow(/Invalid/)
+  })
+})
+
+describe('resolveMigrationTimeouts', () => {
+  const ORIGINAL = { ...process.env }
+
+  afterEach(() => {
+    process.env.MIGRATION_LOCK_TIMEOUT_MS = ORIGINAL.MIGRATION_LOCK_TIMEOUT_MS
+    process.env.MIGRATION_STATEMENT_TIMEOUT_MS = ORIGINAL.MIGRATION_STATEMENT_TIMEOUT_MS
+    if (ORIGINAL.MIGRATION_LOCK_TIMEOUT_MS === undefined) delete process.env.MIGRATION_LOCK_TIMEOUT_MS
+    if (ORIGINAL.MIGRATION_STATEMENT_TIMEOUT_MS === undefined) {
+      delete process.env.MIGRATION_STATEMENT_TIMEOUT_MS
+    }
+  })
+
+  it('uses documented defaults when env and overrides are absent', () => {
+    delete process.env.MIGRATION_LOCK_TIMEOUT_MS
+    delete process.env.MIGRATION_STATEMENT_TIMEOUT_MS
+    expect(resolveMigrationTimeouts({}, {})).toEqual({
+      lockTimeoutMs: DEFAULT_MIGRATION_LOCK_TIMEOUT_MS,
+      statementTimeoutMs: DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS,
+    })
+  })
+
+  it('reads env defaults', () => {
+    expect(
+      resolveMigrationTimeouts({}, {
+        MIGRATION_LOCK_TIMEOUT_MS: '2500',
+        MIGRATION_STATEMENT_TIMEOUT_MS: '120000',
+      })
+    ).toEqual({ lockTimeoutMs: 2500, statementTimeoutMs: 120_000 })
+  })
+
+  it('prefers explicit overrides over env', () => {
+    expect(
+      resolveMigrationTimeouts(
+        { lockTimeoutMs: 100, statementTimeoutMs: 0 },
+        { MIGRATION_LOCK_TIMEOUT_MS: '9999', MIGRATION_STATEMENT_TIMEOUT_MS: '9999' }
+      )
+    ).toEqual({ lockTimeoutMs: 100, statementTimeoutMs: 0 })
+  })
+
+  it('rejects invalid env values', () => {
+    expect(() =>
+      resolveMigrationTimeouts({}, { MIGRATION_LOCK_TIMEOUT_MS: 'nope' })
+    ).toThrow(/MIGRATION_LOCK_TIMEOUT_MS/)
+  })
+})
+
+describe('applyMigrationTimeouts', () => {
+  it('issues SET LOCAL for lock and statement timeouts with integer ms', async () => {
+    const client = makeMockClient()
+    await applyMigrationTimeouts(client as never, {
+      lockTimeoutMs: 5_000,
+      statementTimeoutMs: 60_000,
+    })
+    expect(client.calls).toEqual([
+      'SET LOCAL lock_timeout = 5000',
+      'SET LOCAL statement_timeout = 60000',
+    ])
+  })
+
+  it('allows statement_timeout = 0 for long index builds', async () => {
+    const client = makeMockClient()
+    await applyMigrationTimeouts(client as never, {
+      lockTimeoutMs: 5_000,
+      statementTimeoutMs: 0,
+    })
+    expect(client.calls).toContain('SET LOCAL statement_timeout = 0')
+    expect(client.calls).toContain('SET LOCAL lock_timeout = 5000')
+  })
+})
+
+describe('classifyTimeoutBreach', () => {
+  it('classifies PostgreSQL lock_timeout (55P03)', () => {
+    expect(classifyTimeoutBreach({ code: PG_LOCK_NOT_AVAILABLE, message: 'canceling statement due to lock timeout' }))
+      .toBe('lock_timeout')
+  })
+
+  it('classifies PostgreSQL statement_timeout (57014)', () => {
+    expect(classifyTimeoutBreach({ code: PG_QUERY_CANCELED, message: 'canceling statement due to statement timeout' }))
+      .toBe('statement_timeout')
+  })
+
+  it('falls back to message matching when code is absent', () => {
+    expect(classifyTimeoutBreach({ message: 'ERROR: lock timeout' })).toBe('lock_timeout')
+    expect(classifyTimeoutBreach({ message: 'canceling statement due to statement timeout' }))
+      .toBe('statement_timeout')
+  })
+
+  it('returns null for unrelated errors', () => {
+    expect(classifyTimeoutBreach({ code: '23505', message: 'duplicate key' })).toBeNull()
+    expect(classifyTimeoutBreach(null)).toBeNull()
+  })
+})
+
+describe('emitMigrationTimeoutAudit', () => {
+  it('emits a structured audit record via the provided sink', () => {
+    const sink = vi.fn()
+    const record = emitMigrationTimeoutAudit(
+      {
+        version: '001_users',
+        direction: 'up',
+        breach: 'lock_timeout',
+        lockTimeoutMs: 5000,
+        statementTimeoutMs: 60000,
+        pgCode: PG_LOCK_NOT_AVAILABLE,
+        message: 'lock timeout',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+      sink
+    )
+    expect(record.event).toBe('migration_timeout_breach')
+    expect(sink).toHaveBeenCalledWith(record)
+  })
+
+  it('defaults to logger.error when no sink is provided', () => {
+    emitMigrationTimeoutAudit({
+      version: '001_users',
+      direction: 'up',
+      breach: 'statement_timeout',
+      lockTimeoutMs: 5000,
+      statementTimeoutMs: 60000,
+      message: 'statement timeout',
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'migration_timeout_breach', breach: 'statement_timeout' })
+    )
+  })
+})
+
 // ─── runMigrations ───────────────────────────────────────────────────────────
 describe('runMigrations', () => {
   beforeEach(() => vi.clearAllMocks())
@@ -155,6 +388,126 @@ describe('runMigrations', () => {
     expect(client.calls).toContain('BEGIN')
     expect(client.calls).toContain('COMMIT')
     expect(client.calls.filter((q) => q === 'COMMIT')).toHaveLength(2)
+  })
+
+  it('sets default lock_timeout and statement_timeout before DDL', async () => {
+    stubLegacyMigration('CREATE TABLE x();')
+    const client = makeMockClient([])
+    await runMigrations(client as never, '/fake')
+
+    const beginIdx = client.calls.indexOf('BEGIN')
+    const lockIdx = client.calls.findIndex((q) => q.startsWith('SET LOCAL lock_timeout'))
+    const stmtIdx = client.calls.findIndex((q) => q.startsWith('SET LOCAL statement_timeout'))
+    const ddlIdx = client.calls.findIndex((q) => q.trim() === 'CREATE TABLE x();')
+
+    expect(beginIdx).toBeGreaterThanOrEqual(0)
+    expect(lockIdx).toBeGreaterThan(beginIdx)
+    expect(stmtIdx).toBeGreaterThan(lockIdx)
+    expect(ddlIdx).toBeGreaterThan(stmtIdx)
+    expect(client.calls[lockIdx]).toBe(`SET LOCAL lock_timeout = ${DEFAULT_MIGRATION_LOCK_TIMEOUT_MS}`)
+    expect(client.calls[stmtIdx]).toBe(
+      `SET LOCAL statement_timeout = ${DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS}`
+    )
+  })
+
+  it('honours per-migration overrides for long index builds', async () => {
+    const sql = `
+-- @lock_timeout_ms 5000
+-- @statement_timeout_ms 0
+CREATE INDEX idx_big ON events (created_at);
+`.trim()
+    stubLegacyMigration(sql)
+    const client = makeMockClient([])
+    await runMigrations(client as never, '/fake')
+
+    expect(client.calls).toContain('SET LOCAL lock_timeout = 5000')
+    expect(client.calls).toContain('SET LOCAL statement_timeout = 0')
+    expect(client.calls).toContain(sql)
+    expect(client.calls).toContain('COMMIT')
+  })
+
+  it('fails fast on lock_timeout breach, rolls back, and emits audit', async () => {
+    stubLegacyMigration('ALTER TABLE users ADD COLUMN x int;')
+    const audit = vi.fn()
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      if (sql.includes('ALTER TABLE')) {
+        const err = Object.assign(new Error('canceling statement due to lock timeout'), {
+          code: PG_LOCK_NOT_AVAILABLE,
+        })
+        throw err
+      }
+      return { rows: [] }
+    })
+
+    await expect(
+      runMigrations(client as never, '/fake', { onAudit: audit })
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(MigrationTimeoutError)
+      const e = err as MigrationTimeoutError
+      expect(e.breach).toBe('lock_timeout')
+      expect(e.version).toBe('001_users')
+      expect(e.code).toBe('MIGRATION_TIMEOUT')
+      return true
+    })
+
+    expect(client.calls).toContain('ROLLBACK')
+    expect(client.calls).not.toContain('COMMIT')
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'migration_timeout_breach',
+        breach: 'lock_timeout',
+        version: '001_users',
+        direction: 'up',
+        pgCode: PG_LOCK_NOT_AVAILABLE,
+      })
+    )
+  })
+
+  it('fails fast on statement_timeout breach and emits audit', async () => {
+    stubLegacyMigration('CREATE INDEX idx ON t(id);')
+    const audit = vi.fn()
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      if (sql.includes('CREATE INDEX')) {
+        throw Object.assign(new Error('canceling statement due to statement timeout'), {
+          code: PG_QUERY_CANCELED,
+        })
+      }
+      return { rows: [] }
+    })
+
+    await expect(
+      runMigrations(client as never, '/fake', { onAudit: audit })
+    ).rejects.toBeInstanceOf(MigrationTimeoutError)
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'migration_timeout_breach',
+        breach: 'statement_timeout',
+        direction: 'up',
+      })
+    )
+    expect(client.calls).toContain('ROLLBACK')
+  })
+
+  it('does not emit timeout audit for unrelated SQL failures', async () => {
+    stubLegacyMigration('CREATE TABLE x();')
+    const audit = vi.fn()
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      if (sql.trim() === 'CREATE TABLE x();') throw new Error('Simulated DB failure')
+      return { rows: [] }
+    })
+
+    await expect(
+      runMigrations(client as never, '/fake', { onAudit: audit })
+    ).rejects.toThrow('Simulated DB failure')
+    expect(audit).not.toHaveBeenCalled()
+    expect(client.calls).toContain('ROLLBACK')
   })
 
   it('skips already-applied migrations', async () => {
@@ -190,6 +543,16 @@ describe('runMigrations', () => {
     await expect(runMigrations(client as never, '/fake')).rejects.toThrow('Simulated DB failure')
     expect(client.calls).toContain('ROLLBACK')
   })
+
+  it('applies run-level timeout options when file has none', async () => {
+    stubLegacyMigration('CREATE TABLE x();')
+    const client = makeMockClient([])
+    await runMigrations(client as never, '/fake', {
+      timeouts: { lockTimeoutMs: 1500, statementTimeoutMs: 45_000 },
+    })
+    expect(client.calls).toContain('SET LOCAL lock_timeout = 1500')
+    expect(client.calls).toContain('SET LOCAL statement_timeout = 45000')
+  })
 })
 
 // ─── runRollback ─────────────────────────────────────────────────────────────
@@ -213,6 +576,58 @@ describe('runRollback', () => {
     expect(client.calls).toContain('BEGIN')
     expect(client.calls).toContain('COMMIT')
     expect(client.calls).toContain('DELETE FROM schema_migrations WHERE version = $1')
+  })
+
+  it('applies timeout guards during rollback', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE users;')
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '001_users' }] }
+      }
+      return { rows: [] }
+    })
+
+    await runRollback(client as never, 1, '/fake')
+    expect(client.calls).toContain(`SET LOCAL lock_timeout = ${DEFAULT_MIGRATION_LOCK_TIMEOUT_MS}`)
+    expect(client.calls).toContain(
+      `SET LOCAL statement_timeout = ${DEFAULT_MIGRATION_STATEMENT_TIMEOUT_MS}`
+    )
+  })
+
+  it('emits audit and fails fast when rollback hits lock_timeout', async () => {
+    mockAccess.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue('DROP TABLE users;')
+    const audit = vi.fn()
+
+    const client = makeMockClient([])
+    withQueryImpl(client, async (sql) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) {
+        return { rows: [{ version: '001_users' }] }
+      }
+      if (sql.trim() === 'DROP TABLE users;') {
+        throw Object.assign(new Error('canceling statement due to lock timeout'), {
+          code: PG_LOCK_NOT_AVAILABLE,
+        })
+      }
+      return { rows: [] }
+    })
+
+    await expect(
+      runRollback(client as never, 1, '/fake', { onAudit: audit })
+    ).rejects.toBeInstanceOf(MigrationTimeoutError)
+
+    expect(audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'migration_timeout_breach',
+        direction: 'down',
+        breach: 'lock_timeout',
+        version: '001_users',
+      })
+    )
+    expect(client.calls).toContain('ROLLBACK')
   })
 
   it('does nothing when schema_migrations is empty', async () => {
@@ -284,5 +699,109 @@ describe('runRollback', () => {
 
     await expect(runRollback(client as never, 2, '/fake')).rejects.toThrow('Cannot roll back')
     expect(client.calls).not.toContain('BEGIN')
+  })
+})
+
+describe('MIGRATIONS_DIR', () => {
+  it('points at the migrations directory under src/db', () => {
+    expect(MIGRATIONS_DIR).toMatch(/migrations$/)
+  })
+})
+
+describe('CLI helpers', () => {
+  it('isMigrateCliEntrypoint compares argv path to module URL', async () => {
+    const { isMigrateCliEntrypoint } = await import('../../src/db/migrate')
+    const moduleUrl = import.meta.url
+    const selfPath = fileURLToPath(moduleUrl)
+    expect(isMigrateCliEntrypoint(selfPath, moduleUrl)).toBe(true)
+    expect(isMigrateCliEntrypoint(undefined, moduleUrl)).toBe(false)
+    expect(isMigrateCliEntrypoint('/other/path', moduleUrl)).toBe(false)
+  })
+
+  it('handleMigrateCliFailure logs and exits', async () => {
+    const { handleMigrateCliFailure } = await import('../../src/db/migrate')
+    const exitFn = vi.fn(() => {
+      throw new Error('exited')
+    }) as unknown as (code: number) => never
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(handleMigrateCliFailure(new Error('boom'), exitFn)).rejects.toThrow('exited')
+    expect(errSpy).toHaveBeenCalledWith('Fatal:', 'boom')
+    expect(exitFn).toHaveBeenCalledWith(1)
+    errSpy.mockRestore()
+  })
+
+  it('runMigrateCli exits when DATABASE_URL is missing', async () => {
+    const { runMigrateCli } = await import('../../src/db/migrate')
+    const exitFn = vi.fn(() => {
+      throw new Error('exited')
+    }) as unknown as (code: number) => never
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(runMigrateCli({}, ['node', 'migrate.ts'], exitFn)).rejects.toThrow('exited')
+    expect(errSpy).toHaveBeenCalledWith('DATABASE_URL is required.')
+    expect(exitFn).toHaveBeenCalledWith(1)
+    errSpy.mockRestore()
+  })
+
+  it('runMigrateCli connects and runs migrations', async () => {
+    const { runMigrateCli } = await import('../../src/db/migrate')
+    mockReaddir.mockResolvedValue([])
+    const connect = vi.fn(async () => {})
+    const end = vi.fn(async () => {})
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      return { rows: [] }
+    })
+    class FakeClient {
+      connect = connect
+      end = end
+      query = query
+      constructor(_opts: { connectionString: string }) {}
+    }
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await runMigrateCli(
+      { DATABASE_URL: 'postgresql://localhost/test' },
+      ['node', 'migrate.ts'],
+      ((() => {
+        throw new Error('should not exit')
+      }) as never),
+      FakeClient as never
+    )
+    expect(connect).toHaveBeenCalled()
+    expect(end).toHaveBeenCalled()
+    expect(logSpy).toHaveBeenCalledWith('No pending migrations.')
+    logSpy.mockRestore()
+  })
+
+  it('runMigrateCli runs rollback when argv requests it', async () => {
+    const { runMigrateCli } = await import('../../src/db/migrate')
+    const connect = vi.fn(async () => {})
+    const end = vi.fn(async () => {})
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('SELECT version FROM schema_migrations')) return { rows: [] }
+      return { rows: [] }
+    })
+    class FakeClient {
+      connect = connect
+      end = end
+      query = query
+      constructor(_opts: { connectionString: string }) {}
+    }
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await runMigrateCli(
+      { DATABASE_URL: 'postgresql://localhost/test' },
+      ['node', 'migrate.ts', 'rollback', '2'],
+      ((() => {
+        throw new Error('should not exit')
+      }) as never),
+      FakeClient as never
+    )
+    expect(connect).toHaveBeenCalled()
+    expect(end).toHaveBeenCalled()
+    expect(logSpy).toHaveBeenCalledWith('Nothing to roll back.')
+    logSpy.mockRestore()
   })
 })


### PR DESCRIPTION
Prevent long-running DDL from stalling traffic by setting SET LOCAL lock_timeout and statement_timeout on every migration transaction, failing fast with a migration_timeout_breach audit event on breach, and allowing per-file overrides for long index builds. Closes #571