### PR TITLE
feat: add cross-region failover for AWS Secrets Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,19 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/veritasor
 # OTEL_SERVICE_NAME=veritasor-backend
 
 # ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# AWS Secrets Manager (for SECRET_PROVIDER=aws)
+# ------------------------------------------------------------------------------
+
+# Primary region for Secrets Manager.
+# AWS_REGION=us-east-1
+
+# Secondary region for cross-region DR failover.
+# When set, the loader retries the secondary region on 5xx / network errors
+# before falling back to environment variables.
+# AWS_SECONDARY_REGION=us-west-2
+
+# ------------------------------------------------------------------------------
 # Stellar & Soroban
 # ------------------------------------------------------------------------------
 

--- a/src/utils/secret-loader.spec.ts
+++ b/src/utils/secret-loader.spec.ts
@@ -7,6 +7,14 @@ import {
   SecretNotFoundError,
   SecretLoadError,
 } from './secret-loader.js'
+import { logger } from './logger.js'
+
+let mockSend: ReturnType<typeof vi.fn>
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: vi.fn(function () { return { send: mockSend } }),
+  GetSecretValueCommand: vi.fn(),
+}))
 
 const ORIGINAL_ENV = { ...process.env }
 
@@ -65,20 +73,106 @@ describe('SecretLoader', () => {
   })
 
   describe('AwsSecretsAdapter', () => {
+    beforeEach(() => {
+      mockSend = vi.fn()
+    })
+
     it('loads secrets from AWS Secrets Manager', async () => {
-      const mockSend = vi.fn(async () => ({
-        SecretString: '{"AWS_SECRET": "aws-value"}',
+      mockSend.mockResolvedValue({ SecretString: '{"AWS_SECRET": "aws-value"}' })
+      const loader = new AwsSecretsAdapter('us-east-1')
+      await loader.reload()
+      expect(await loader.get('test-secret')).toBe('aws-value')
+      expect(mockSend).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails over to secondary region on 5xx', async () => {
+      mockSend
+        .mockRejectedValueOnce(Object.assign(new Error('Service error'), {
+          $metadata: { httpStatusCode: 500 },
+        }))
+        .mockResolvedValueOnce({ SecretString: '{"SECRET": "secondary-value"}' })
+
+      const loader = new AwsSecretsAdapter('us-east-1', 'us-west-2')
+      await loader.reload()
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      const result = await loader.get('SECRET')
+      expect(result).toBe('secondary-value')
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(warnSpy).toHaveBeenCalledWith({
+        event: 'secrets_failover',
+        from: 'us-east-1',
+        to: 'us-west-2',
+      })
+    })
+
+    it('fails over on network timeout', async () => {
+      mockSend
+        .mockRejectedValueOnce(new Error('Connection timeout'))
+        .mockResolvedValueOnce({ SecretString: '{"SECRET": "secondary-value"}' })
+
+      const loader = new AwsSecretsAdapter('us-east-1', 'us-west-2')
+      await loader.reload()
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      const result = await loader.get('SECRET')
+      expect(result).toBe('secondary-value')
+      expect(mockSend).toHaveBeenCalledTimes(2)
+      expect(warnSpy).toHaveBeenCalledOnce()
+    })
+
+    it('does not fail over on ResourceNotFoundException', async () => {
+      mockSend.mockRejectedValueOnce(Object.assign(new Error('Not found'), {
+        name: 'ResourceNotFoundException',
+        $metadata: { httpStatusCode: 404 },
       }))
-      
-      vi.mock('@aws-sdk/client-secrets-manager', () => ({
-        SecretsManagerClient: vi.fn(() => ({ send: mockSend })),
-        GetSecretValueCommand: vi.fn(),
+
+      const loader = new AwsSecretsAdapter('us-east-1', 'us-west-2')
+      await loader.reload()
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      await expect(loader.get('SECRET')).rejects.toThrow(SecretLoadError)
+      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('throws when all regions fail', async () => {
+      mockSend.mockRejectedValue(Object.assign(new Error('Service error'), {
+        $metadata: { httpStatusCode: 500 },
+      }))
+
+      const loader = new AwsSecretsAdapter('us-east-1', 'us-west-2')
+      await loader.reload()
+
+      await expect(loader.get('SECRET')).rejects.toThrow(SecretLoadError)
+      expect(mockSend).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not retry when no secondary region configured', async () => {
+      mockSend.mockRejectedValue(Object.assign(new Error('Service error'), {
+        $metadata: { httpStatusCode: 500 },
       }))
 
       const loader = new AwsSecretsAdapter('us-east-1')
       await loader.reload()
-      expect(await loader.get('test-secret')).toBe('aws-value')
-      expect(mockSend).toHaveBeenCalled()
+
+      await expect(loader.get('SECRET')).rejects.toThrow(SecretLoadError)
+      expect(mockSend).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses primary value when primary succeeds (divergent secrets)', async () => {
+      mockSend
+        .mockResolvedValueOnce({ SecretString: '{"SECRET": "primary-value"}' })
+        .mockResolvedValueOnce({ SecretString: '{"SECRET": "secondary-value"}' })
+
+      const loader = new AwsSecretsAdapter('us-east-1', 'us-west-2')
+      await loader.reload()
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      const result = await loader.get('SECRET')
+      expect(result).toBe('primary-value')
+      expect(mockSend).toHaveBeenCalledTimes(1)
+      expect(warnSpy).not.toHaveBeenCalled()
     })
   })
 
@@ -142,6 +236,14 @@ describe('SecretLoader', () => {
 
     it('throws when required AWS config is missing', () => {
       expect(() => createSecretLoader({ provider: 'aws' })).toThrow(SecretLoadError)
+    })
+
+    it('accepts awsSecondaryRegion option', () => {
+      expect(() => createSecretLoader({
+        provider: 'aws',
+        awsRegion: 'us-east-1',
+        awsSecondaryRegion: 'us-west-2',
+      })).not.toThrow()
     })
 
     it('throws when required Vault config is missing', () => {

--- a/src/utils/secret-loader.ts
+++ b/src/utils/secret-loader.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import dotenv from 'dotenv'
+import { logger } from './logger.js'
 
 export interface SecretAdapter {
   get(key: string): Promise<string>
@@ -45,6 +46,7 @@ export interface SecretLoaderOptions {
   timeout?: number
   fallbackEnabled?: boolean
   awsRegion?: string
+  awsSecondaryRegion?: string
   vaultBaseUrl?: string
   vaultSecretPath?: string
   vaultToken?: string
@@ -165,7 +167,10 @@ export class VaultAdapter extends BaseSecretAdapter {
 }
 
 export class AwsSecretsAdapter extends BaseSecretAdapter {
-  constructor(private readonly region: string) {
+  constructor(
+    private readonly primaryRegion: string,
+    private readonly secondaryRegion?: string,
+  ) {
     super()
   }
 
@@ -175,27 +180,80 @@ export class AwsSecretsAdapter extends BaseSecretAdapter {
 
   async get(key: string): Promise<string> {
     this.ensureLoaded()
-    try {
-      const { SecretsManagerClient, GetSecretValueCommand } = await import('@aws-sdk/client-secrets-manager')
-      const client = new SecretsManagerClient({ region: this.region })
-      const command = new GetSecretValueCommand({ SecretId: key })
-      const response = await client.send(command)
-      
-      if (response.SecretString) {
-        try {
-          const parsed = JSON.parse(response.SecretString)
-          if (parsed && typeof parsed === 'object') {
-            this.secrets = BaseSecretAdapter.normalizeSecretValues(parsed)
-            return this.toSecretValue(Object.values(parsed)[0] as string | undefined, key)
-          }
-        } catch {
-          return this.toSecretValue(response.SecretString, key)
-        }
-      }
-      throw new SecretLoadError(`Secret ${key} has no SecretString`)
-    } catch (error) {
-      throw new SecretLoadError(`Failed to fetch secret from AWS Secrets Manager: ${key}`, error instanceof Error ? error : undefined)
+
+    const regions: string[] = [this.primaryRegion]
+    if (this.secondaryRegion) {
+      regions.push(this.secondaryRegion)
     }
+
+    let lastError: Error | undefined
+
+    for (let i = 0; i < regions.length; i++) {
+      try {
+        return await this.getFromRegion(regions[i], key)
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+        if (i < regions.length - 1 && this.isRetryableError(error)) {
+          logger.warn({
+            event: 'secrets_failover',
+            from: this.primaryRegion,
+            to: regions[i + 1],
+          })
+          continue
+        }
+        throw new SecretLoadError(
+          `Failed to fetch secret from AWS Secrets Manager: ${key}`,
+          lastError,
+        )
+      }
+    }
+
+    throw new SecretLoadError(
+      `Failed to fetch secret from AWS Secrets Manager: ${key}`,
+      lastError,
+    )
+  }
+
+  private async getFromRegion(region: string, key: string): Promise<string> {
+    const { SecretsManagerClient, GetSecretValueCommand } = await import('@aws-sdk/client-secrets-manager')
+    const client = new SecretsManagerClient({ region })
+    const command = new GetSecretValueCommand({ SecretId: key })
+    const response = await client.send(command)
+
+    if (response.SecretString) {
+      try {
+        const parsed = JSON.parse(response.SecretString)
+        if (parsed && typeof parsed === 'object') {
+          this.secrets = BaseSecretAdapter.normalizeSecretValues(parsed)
+          return this.toSecretValue(Object.values(parsed)[0] as string | undefined, key)
+        }
+      } catch {
+        return this.toSecretValue(response.SecretString, key)
+      }
+    }
+    throw new SecretLoadError(`Secret ${key} has no SecretString`)
+  }
+
+  // Secondary region is DR fallback only, not a reconciliation source.
+  private isRetryableError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false
+
+    const err = error as Record<string, unknown>
+    const metadata = err.$metadata as Record<string, unknown> | undefined
+
+    if (metadata?.httpStatusCode && Number(metadata.httpStatusCode) >= 500) {
+      return true
+    }
+
+    if (!metadata) {
+      const name = String(err.name ?? '')
+      const message = String(err.message ?? '')
+      if (/timeout|network|connection|econnrefused|enotfound|etimedout/i.test(name + ' ' + message)) {
+        return true
+      }
+    }
+
+    return false
   }
 }
 
@@ -251,7 +309,8 @@ export function createSecretLoader(options: SecretLoaderOptions = {}): SecretAda
       if (!region) {
         throw new SecretLoadError('AWS_REGION is required when SECRET_PROVIDER=aws')
       }
-      primaryAdapter = new AwsSecretsAdapter(region)
+      const secondaryRegion = options.awsSecondaryRegion ?? process.env.AWS_SECONDARY_REGION
+      primaryAdapter = new AwsSecretsAdapter(region, secondaryRegion)
       break
     }
     case 'vault': {


### PR DESCRIPTION
- Added optional cross-region failover support to `AwsSecretsAdapter` via `AWS_SECONDARY_REGION`
- Automatically retries secret reads against the secondary region on AWS 5xx responses and network/timeout failures
- Emits a structured `secrets_failover` event when failing over between regions (secret identifiers intentionally omitted)
- Preserves fail-fast behavior for non-retryable errors such as `ResourceNotFoundException` and `AccessDeniedException`
- Added comprehensive test coverage for failover, timeout, non-retryable errors, all-regions-fail, single-region mode, divergent secrets, and `createSecretLoader` configuration
- Documented `AWS_REGION` and `AWS_SECONDARY_REGION` configuration in `.env.example`

Closes #555