### PR TITLE
feat: shared secret provider contract tests

### DIFF
--- a/src/utils/secret-provider.contract.spec.ts
+++ b/src/utils/secret-provider.contract.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, vi } from 'vitest'
+import { EnvAdapter, VaultAdapter, AwsSecretsAdapter } from './secret-loader.js'
+import { describeSecretProviderContract } from './secret-provider.contract.js'
+
+let mockSecretString: string
+let mockSend: ReturnType<typeof vi.fn>
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: vi.fn(function () {
+    return { send: mockSend }
+  }),
+  GetSecretValueCommand: vi.fn(function (input: { SecretId: string }) { return input }),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key]
+    }
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  restoreEnv()
+  vi.restoreAllMocks()
+})
+
+describeSecretProviderContract('EnvAdapter', async () => ({
+  adapter: new EnvAdapter(),
+  seed: (key, value) => { process.env[key] = value },
+}))
+
+describeSecretProviderContract('VaultAdapter', async () => {
+  let payload: Record<string, unknown> = { data: {} }
+
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn(async () => payload),
+  })) as typeof fetch)
+
+  return {
+    adapter: new VaultAdapter('https://vault.example.com', 'secrets', 'token'),
+    seed: (_key, value) => { payload = { data: { CONTRACT_TEST_KEY: value } } },
+  }
+})
+
+describeSecretProviderContract('AwsSecretsAdapter', async () => {
+  mockSend = vi.fn(async (command) => {
+    const key = command.SecretId
+    if (key === 'CONTRACT_MISSING_KEY') {
+      throw Object.assign(new Error('Secrets Manager can\'t find the specified secret'), {
+        name: 'ResourceNotFoundException',
+        $metadata: { httpStatusCode: 404 },
+      })
+    }
+    return { SecretString: mockSecretString }
+  })
+
+  return {
+    adapter: new AwsSecretsAdapter('us-east-1'),
+    seed: (_key, value) => { mockSecretString = JSON.stringify({ CONTRACT_TEST_KEY: value }) },
+  }
+})

--- a/src/utils/secret-provider.contract.ts
+++ b/src/utils/secret-provider.contract.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { SecretAdapter } from './secret-loader.js'
+
+export interface ProviderContext {
+  adapter: SecretAdapter
+  seed?: (key: string, value: string) => void
+}
+
+export function describeSecretProviderContract(
+  name: string,
+  createAdapter: () => Promise<ProviderContext>,
+): void {
+  const KEY = 'CONTRACT_TEST_KEY'
+  const VALUE = 'contract-test-value'
+  const MISSING = 'CONTRACT_MISSING_KEY'
+
+  describe(`${name} contract`, () => {
+    it('createAdapter() resolves', async () => {
+      const ctx = await createAdapter()
+      expect(ctx.adapter).toBeDefined()
+    })
+
+    it('get(knownKey) returns a string after reload()', async () => {
+      const ctx = await createAdapter()
+      if (ctx.seed) ctx.seed(KEY, VALUE)
+      await ctx.adapter.reload()
+      const result = await ctx.adapter.get(KEY)
+      expect(typeof result).toBe('string')
+      expect(result).toBe(VALUE)
+    })
+
+    it('get(unknownKey) throws an error', async () => {
+      const ctx = await createAdapter()
+      if (ctx.seed) ctx.seed(KEY, VALUE)
+      await ctx.adapter.reload()
+      await expect(ctx.adapter.get(MISSING)).rejects.toThrow()
+    })
+
+    it('reload() resolves', async () => {
+      const ctx = await createAdapter()
+      if (ctx.seed) ctx.seed(KEY, VALUE)
+      await expect(ctx.adapter.reload()).resolves.toBeUndefined()
+    })
+
+    it('reload() is idempotent', async () => {
+      const ctx = await createAdapter()
+      if (ctx.seed) ctx.seed(KEY, VALUE)
+      await ctx.adapter.reload()
+      await expect(ctx.adapter.reload()).resolves.toBeUndefined()
+    })
+
+    it('reload() reflects updated values', async () => {
+      const ctx = await createAdapter()
+      if (ctx.seed) ctx.seed(KEY, VALUE)
+      await ctx.adapter.reload()
+      const first = await ctx.adapter.get(KEY)
+
+      const UPDATED = 'contract-test-updated'
+      if (ctx.seed) ctx.seed(KEY, UPDATED)
+      await ctx.adapter.reload()
+      const second = await ctx.adapter.get(KEY)
+
+      expect(first).toBe(VALUE)
+      expect(second).toBe(UPDATED)
+    })
+  })
+}


### PR DESCRIPTION
## Description

Adds a reusable contract test suite for `SecretAdapter` implementations to ensure all secret providers satisfy the same behavior and prevent provider drift as new backends are introduced.

## Related Issue

Closes #557

## Changes

- Added `src/utils/secret-provider.contract.ts` containing a reusable contract test suite for `SecretAdapter` implementations.
- Added `src/utils/secret-provider.contract.spec.ts` to run the contract against:
  - `EnvAdapter`
  - `VaultAdapter`
  - `AwsSecretsAdapter`
- Verified the shared contract for:
  - Adapter initialization
  - Secret retrieval
  - Missing secret handling
  - `reload()` behavior
  - Reload idempotency
  - Secret rotation after reload

## Test Results

```text
✓ src/utils/secret-provider.contract.spec.ts
18 tests passed
0 failures
```

## Notes

- No production code was modified.
- Existing adapters and the `SecretAdapter` interface remain unchanged.
- Future providers only need to register with the contract suite to automatically inherit the shared behavior checks.