### PR TITLE
feat: publish webhook egress IP allow-list and signed audit-log export

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
     "jsonwebtoken": "^9.0.2",
     "kafkajs": "2.2.4",
     "nodemailer": "^8.0.10",
+    "openpgp": "^6.3.1",
     "pg": "^8.13.1",
     "prom-client": "^15.1.3",
+    "tar-stream": "^3.2.0",
     "tinypool": "^0.8.4",
     "ws": "8.18.0",
     "zod": "^3.23.8"
@@ -70,6 +72,7 @@
     "@types/nodemailer": "^6.4.16",
     "@types/pg": "^8.11.6",
     "@types/supertest": "^6.0.3",
+    "@types/tar-stream": "^3.1.4",
     "@types/ws": "8.5.13",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@google-cloud/secret-manager':
         specifier: ^5.6.0
-        version: 5.6.0(encoding@0.1.13)(supports-color@8.1.1)
+        version: 5.6.0(encoding@0.1.13)
       '@graphql-tools/schema':
         specifier: ^10.0.38
         version: 10.0.38(graphql@17.0.2)
@@ -43,10 +43,10 @@ importers:
         version: 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.57.2
-        version: 0.57.2(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+        version: 0.57.2(@opentelemetry/api@1.9.1)
       '@stellar/stellar-sdk':
         specifier: ^14.5.0
-        version: 14.6.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 14.6.1
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -64,7 +64,7 @@ importers:
         version: 16.6.1
       express:
         specifier: ^4.21.1
-        version: 4.22.2(supports-color@8.1.1)
+        version: 4.22.2
       fzstd:
         specifier: ^0.1.1
         version: 0.1.1
@@ -79,7 +79,7 @@ importers:
         version: 8.3.0
       ioredis:
         specifier: 5.3.2
-        version: 5.3.2(supports-color@8.1.1)
+        version: 5.3.2
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -89,12 +89,18 @@ importers:
       nodemailer:
         specifier: ^8.0.10
         version: 8.0.11
+      openpgp:
+        specifier: ^6.3.1
+        version: 6.3.1
       pg:
         specifier: ^8.13.1
         version: 8.22.0
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      tar-stream:
+        specifier: ^3.2.0
+        version: 3.2.0
       tinypool:
         specifier: ^0.8.4
         version: 0.8.4
@@ -107,19 +113,19 @@ importers:
     devDependencies:
       '@cyclonedx/cyclonedx-npm':
         specifier: ^4.2.1
-        version: 4.2.1(supports-color@8.1.1)
+        version: 4.2.1
       '@jest/globals':
         specifier: ^29.7.0
-        version: 29.7.0(supports-color@8.1.1)
+        version: 29.7.0
       '@pact-foundation/pact':
         specifier: ^13.2.0
-        version: 13.2.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 13.2.0
       '@stryker-mutator/core':
         specifier: ^9.6.1
-        version: 9.6.1(@types/node@22.20.0)(supports-color@8.1.1)
+        version: 9.6.1(@types/node@22.20.0)
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.0)(supports-color@8.1.1))(vitest@4.1.10)
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.0))(vitest@4.1.10)
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -147,6 +153,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
+      '@types/tar-stream':
+        specifier: ^3.1.4
+        version: 3.1.4
       '@types/ws':
         specifier: 8.5.13
         version: 8.5.13
@@ -155,25 +164,25 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       eslint:
         specifier: ^9.15.0
-        version: 9.39.4(supports-color@8.1.1)
+        version: 9.39.4
       fast-check:
         specifier: ^4.6.0
         version: 4.8.0
       jest:
         specifier: ^30.2.0
-        version: 30.4.2(@types/node@22.20.0)(supports-color@8.1.1)
+        version: 30.4.2(@types/node@22.20.0)
       supertest:
         specifier: ^7.2.2
-        version: 7.2.2(supports-color@8.1.1)
+        version: 7.2.2
       testcontainers:
         specifier: ^12.0.1
-        version: 12.0.4(supports-color@8.1.1)
+        version: 12.0.4
       toxiproxy-node:
         specifier: ^1.0.1
         version: 1.0.1
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.11(@babel/core@7.29.7(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.0)(supports-color@8.1.1))(typescript@5.6.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.0))(typescript@5.6.3)
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
@@ -730,12 +739,6 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/schema@10.0.34':
-    resolution: {integrity: sha512-wGCiUuwqDtlXtDvQ00CI+4u0pd3yd/xGGYOiwc9L63KJZwSXdrUv8ajpJ5lMalawc0mpjcCB0ljEQSeUhajuag==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
   '@graphql-tools/schema@10.0.38':
     resolution: {integrity: sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==}
     engines: {node: '>=16.0.0'}
@@ -750,12 +753,6 @@ packages:
 
   '@graphql-tools/utils@10.11.0':
     resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/utils@11.1.1':
-    resolution: {integrity: sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -1741,6 +1738,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -3055,15 +3055,30 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql-tag@2.12.7:
+    resolution: {integrity: sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   graphql-yoga@5.21.2:
     resolution: {integrity: sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql: ^15.2.0 || ^16.0.0
 
+  graphql@14.7.0:
+    resolution: {integrity: sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==}
+    engines: {node: '>= 6.x'}
+    deprecated: 'No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support'
+
   graphql@17.0.2:
     resolution: {integrity: sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==}
     engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -3107,6 +3122,9 @@ packages:
   helmet@8.3.0:
     resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
     engines: {node: '>=18.0.0'}
+
+  help-me@4.2.0:
+    resolution: {integrity: sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==}
 
   hoek@2.16.3:
     resolution: {integrity: sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==}
@@ -4041,6 +4059,15 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openpgp@6.3.1:
+    resolution: {integrity: sha512-7oSPvmlKPojxFoyelT5DWPIAVmqWZh4qU/5pO6bdoShEtRpCw9Sye9IXUQj6EFM3XpgGssqccAr705YtTcLNQw==}
+    engines: {node: '>= 18.0.0', typescript: '>= 5.0.0'}
+    peerDependencies:
+      '@openpgp/web-stream-tools': ~0.3.0
+    peerDependenciesMeta:
+      '@openpgp/web-stream-tools':
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5226,20 +5253,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@8.1.1)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5266,41 +5293,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5310,18 +5337,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -5341,148 +5368,148 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -5492,7 +5519,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -5500,7 +5527,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5515,19 +5542,19 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@cyclonedx/cyclonedx-library@10.1.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(libxmljs2@0.37.0(supports-color@8.1.1))(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@4.0.3)':
+  '@cyclonedx/cyclonedx-library@10.1.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(libxmljs2@0.37.0)(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@4.0.3)':
     optionalDependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       ajv-formats-draft2019: 1.6.1(ajv@8.20.0)
-      libxmljs2: 0.37.0(supports-color@8.1.1)
+      libxmljs2: 0.37.0
       packageurl-js: 2.0.1
       spdx-expression-parse: 4.0.0
       xmlbuilder2: 4.0.3
 
-  '@cyclonedx/cyclonedx-npm@4.2.1(supports-color@8.1.1)':
+  '@cyclonedx/cyclonedx-npm@4.2.1':
     dependencies:
-      '@cyclonedx/cyclonedx-library': 10.1.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(libxmljs2@0.37.0(supports-color@8.1.1))(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@4.0.3)
+      '@cyclonedx/cyclonedx-library': 10.1.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(libxmljs2@0.37.0)(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@4.0.3)
       commander: 14.0.3
       normalize-package-data: 8.0.0
       packageurl-js: 2.0.1
@@ -5537,7 +5564,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       ajv-formats-draft2019: 1.6.1(ajv@8.20.0)
-      libxmljs2: 0.37.0(supports-color@8.1.1)
+      libxmljs2: 0.37.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5668,17 +5695,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
     dependencies:
-      eslint: 9.39.4(supports-color@8.1.1)
+      eslint: 9.39.4
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -5691,10 +5718,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5(supports-color@8.1.1)':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5716,9 +5743,9 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@google-cloud/secret-manager@5.6.0(encoding@0.1.13)(supports-color@8.1.1)':
+  '@google-cloud/secret-manager@5.6.0(encoding@0.1.13)':
     dependencies:
-      google-gax: 4.6.1(encoding@0.1.13)(supports-color@8.1.1)
+      google-gax: 4.6.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5726,7 +5753,7 @@ snapshots:
   '@graphql-tools/batch-delegate@10.0.29(graphql@17.0.2)':
     dependencies:
       '@graphql-tools/delegate': 12.1.1(graphql@17.0.2)
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
       graphql: 17.0.2
@@ -5734,7 +5761,7 @@ snapshots:
 
   '@graphql-tools/batch-execute@10.0.9(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
       graphql: 17.0.2
@@ -5744,8 +5771,8 @@ snapshots:
     dependencies:
       '@graphql-tools/batch-execute': 10.0.9(graphql@17.0.2)
       '@graphql-tools/executor': 1.5.4(graphql@17.0.2)
-      '@graphql-tools/schema': 10.0.34(graphql@17.0.2)
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.38(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@repeaterjs/repeater': 3.1.0
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
@@ -5754,7 +5781,7 @@ snapshots:
 
   '@graphql-tools/executor@1.5.4(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@repeaterjs/repeater': 3.1.0
       '@whatwg-node/disposablestack': 0.0.6
@@ -5764,20 +5791,13 @@ snapshots:
 
   '@graphql-tools/merge@9.1.10(graphql@17.0.2)':
     dependencies:
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       graphql: 17.0.2
       tslib: 2.8.1
 
   '@graphql-tools/merge@9.2.2(graphql@17.0.2)':
     dependencies:
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
-      graphql: 17.0.2
-      tslib: 2.8.1
-
-  '@graphql-tools/schema@10.0.34(graphql@17.0.2)':
-    dependencies:
-      '@graphql-tools/merge': 9.1.10(graphql@17.0.2)
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
       graphql: 17.0.2
       tslib: 2.8.1
 
@@ -5794,22 +5814,14 @@ snapshots:
       '@graphql-tools/delegate': 12.1.1(graphql@17.0.2)
       '@graphql-tools/executor': 1.5.4(graphql@17.0.2)
       '@graphql-tools/merge': 9.1.10(graphql@17.0.2)
-      '@graphql-tools/schema': 10.0.34(graphql@17.0.2)
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.38(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@graphql-tools/wrap': 11.1.21(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 17.0.2
       tslib: 2.8.1
 
   '@graphql-tools/utils@10.11.0(graphql@17.0.2)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
-      graphql: 17.0.2
-      tslib: 2.8.1
-
-  '@graphql-tools/utils@11.1.1(graphql@17.0.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
@@ -5828,8 +5840,8 @@ snapshots:
   '@graphql-tools/wrap@11.1.21(graphql@17.0.2)':
     dependencies:
       '@graphql-tools/delegate': 12.1.1(graphql@17.0.2)
-      '@graphql-tools/schema': 10.0.34(graphql@17.0.2)
-      '@graphql-tools/utils': 11.1.1(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.38(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 17.0.2
       tslib: 2.8.1
@@ -6049,13 +6061,13 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(supports-color@8.1.1)':
+  '@jest/core@30.4.2':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
-      '@jest/reporters': 30.4.1(supports-color@8.1.1)
+      '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 22.20.0
       ansi-escapes: 4.3.2
@@ -6065,15 +6077,15 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@22.20.0)(supports-color@8.1.1)
+      jest-config: 30.4.2(@types/node@22.20.0)
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-resolve-dependencies: 30.4.2(supports-color@8.1.1)
-      jest-runner: 30.4.2(supports-color@8.1.1)
-      jest-runtime: 30.4.2(supports-color@8.1.1)
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
+      jest-resolve-dependencies: 30.4.2
+      jest-runner: 30.4.2
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
       jest-watcher: 30.4.1
@@ -6109,17 +6121,17 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.1.0
 
-  '@jest/expect@29.7.0(supports-color@8.1.1)':
+  '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/expect@30.4.1(supports-color@8.1.1)':
+  '@jest/expect@30.4.1':
     dependencies:
       expect: 30.4.1
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6143,19 +6155,19 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@29.7.0(supports-color@8.1.1)':
+  '@jest/globals@29.7.0':
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@8.1.1)
+      '@jest/expect': 29.7.0
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/globals@30.4.1(supports-color@8.1.1)':
+  '@jest/globals@30.4.1':
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1(supports-color@8.1.1)
+      '@jest/expect': 30.4.1
       '@jest/types': 30.4.1
       jest-mock: 30.4.1
     transitivePeerDependencies:
@@ -6166,12 +6178,12 @@ snapshots:
       '@types/node': 22.20.0
       jest-regex-util: 30.4.0
 
-  '@jest/reporters@30.4.1(supports-color@8.1.1)':
+  '@jest/reporters@30.4.1':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.20.0
@@ -6181,9 +6193,9 @@ snapshots:
       glob: 10.5.0
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
+      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
+      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -6229,12 +6241,12 @@ snapshots:
       jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@29.7.0(supports-color@8.1.1)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -6249,12 +6261,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/transform@30.4.1(supports-color@8.1.1)':
+  '@jest/transform@30.4.1':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
+      babel-plugin-istanbul: 7.0.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -6308,9 +6320,9 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@kwsites/file-exists@1.1.1(supports-color@8.1.1)':
+  '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6334,13 +6346,13 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@npmcli/agent@3.0.0(supports-color@8.1.1)':
+  '@npmcli/agent@3.0.0':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 10.4.3
-      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -6509,13 +6521,13 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2(supports-color@8.1.1)
+      require-in-the-middle: 7.5.2
       semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
@@ -6611,7 +6623,7 @@ snapshots:
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-node@0.57.2(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
+  '@opentelemetry/sdk-node@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -6627,7 +6639,7 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
@@ -6675,18 +6687,18 @@ snapshots:
       pino-pretty: 9.4.1
       underscore: 1.12.1
 
-  '@pact-foundation/pact@13.2.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@pact-foundation/pact@13.2.0':
     dependencies:
       '@pact-foundation/pact-core': 15.2.1
       '@types/express': 4.17.25
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      body-parser: 1.20.5(supports-color@8.1.1)
+      axios: 1.18.1
+      body-parser: 1.20.5
       chalk: 4.1.2
-      express: 4.22.2(supports-color@8.1.1)
+      express: 4.22.2
       graphql: 14.7.0
       graphql-tag: 2.12.7(graphql@14.7.0)
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy: 1.18.1
+      https-proxy-agent: 7.0.6
       js-base64: 3.9.2
       lodash: 4.18.1
       lodash.isfunction: 3.0.8
@@ -6815,10 +6827,10 @@ snapshots:
       buffer: 6.0.3
       sha.js: 2.4.12
 
-  '@stellar/stellar-sdk@14.6.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@stellar/stellar-sdk@14.6.1':
     dependencies:
       '@stellar/stellar-base': 14.1.0
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.18.1
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -6837,11 +6849,11 @@ snapshots:
       tslib: 2.8.1
       typed-inject: 5.0.0
 
-  '@stryker-mutator/core@9.6.1(@types/node@22.20.0)(supports-color@8.1.1)':
+  '@stryker-mutator/core@9.6.1(@types/node@22.20.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@22.20.0)
       '@stryker-mutator/api': 9.6.1
-      '@stryker-mutator/instrumenter': 9.6.1(supports-color@8.1.1)
+      '@stryker-mutator/instrumenter': 9.6.1
       '@stryker-mutator/util': 9.6.1
       ajv: 8.18.0
       chalk: 5.6.2
@@ -6869,14 +6881,14 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  '@stryker-mutator/instrumenter@9.6.1(supports-color@8.1.1)':
+  '@stryker-mutator/instrumenter@9.6.1':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/util': 9.6.1
       angular-html-parser: 10.4.0
@@ -6888,10 +6900,10 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.0)(supports-color@8.1.1))(vitest@4.1.10)':
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@22.20.0))(vitest@4.1.10)':
     dependencies:
       '@stryker-mutator/api': 9.6.1
-      '@stryker-mutator/core': 9.6.1(@types/node@22.20.0)(supports-color@8.1.1)
+      '@stryker-mutator/core': 9.6.1(@types/node@22.20.0)
       '@stryker-mutator/util': 9.6.1
       semver: 7.8.5
       tslib: 2.8.1
@@ -7089,6 +7101,10 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.10
 
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/tough-cookie@4.0.5': {}
 
   '@types/ws@8.5.13':
@@ -7283,9 +7299,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7424,11 +7440,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.18.1:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -7436,35 +7452,35 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@jest/transform': 30.4.1
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.1(supports-color@8.1.1)
-      babel-preset-jest: 30.4.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.4.0(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
+  babel-plugin-istanbul@7.0.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
-      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
+      istanbul-lib-instrument: 6.0.3
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -7473,30 +7489,30 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-jest@30.4.0(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-jest@30.4.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 30.4.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
   balanced-match@1.0.2: {}
 
@@ -7566,11 +7582,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.5(supports-color@8.1.1):
+  body-parser@1.20.5:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -7826,17 +7842,13 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  debug@2.6.9(supports-color@8.1.1):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.4.3(supports-color@8.1.1):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   decompress-response@6.0.0:
     dependencies:
@@ -7893,21 +7905,21 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  docker-modem@5.0.7(supports-color@8.1.1):
+  docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@5.0.1(supports-color@8.1.1):
+  dockerode@5.0.1:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7(supports-color@8.1.1)
+      docker-modem: 5.0.7
       protobufjs: 7.6.4
       tar-fs: 2.1.5
     transitivePeerDependencies:
@@ -8039,14 +8051,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.4(supports-color@8.1.1):
+  eslint@9.39.4:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
+      '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -8056,7 +8068,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -8172,21 +8184,21 @@ snapshots:
   exponential-backoff@3.1.3:
     optional: true
 
-  express@4.22.2(supports-color@8.1.1):
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.5(supports-color@8.1.1)
+      body-parser: 1.20.5
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2(supports-color@8.1.1)
+      finalhandler: 1.3.2
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -8198,8 +8210,8 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2(supports-color@8.1.1)
-      serve-static: 1.16.3(supports-color@8.1.1)
+      send: 0.19.2
+      serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -8269,9 +8281,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.2(supports-color@8.1.1):
+  finalhandler@1.3.2:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8298,9 +8310,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -8362,10 +8372,10 @@ snapshots:
 
   fzstd@0.1.1: {}
 
-  gaxios@6.7.1(encoding@0.1.13)(supports-color@8.1.1):
+  gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
@@ -8373,9 +8383,9 @@ snapshots:
       - encoding
       - supports-color
 
-  gcp-metadata@6.1.1(encoding@0.1.13)(supports-color@8.1.1):
+  gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      gaxios: 6.7.1(encoding@0.1.13)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -8462,31 +8472,31 @@ snapshots:
 
   globals@14.0.0: {}
 
-  google-auth-library@9.15.1(encoding@0.1.13)(supports-color@8.1.1):
+  google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
-      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@8.1.1)
-      gtoken: 7.1.0(encoding@0.1.13)(supports-color@8.1.1)
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@4.6.1(encoding@0.1.13)(supports-color@8.1.1):
+  google-gax@4.6.1(encoding@0.1.13):
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       '@types/long': 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.3
-      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@8.1.1)
+      google-auth-library: 9.15.1(encoding@0.1.13)
       node-fetch: 2.7.0(encoding@0.1.13)
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.4
-      retry-request: 7.0.2(encoding@0.1.13)(supports-color@8.1.1)
+      retry-request: 7.0.2(encoding@0.1.13)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
@@ -8497,6 +8507,11 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql-tag@2.12.7(graphql@14.7.0):
+    dependencies:
+      graphql: 14.7.0
+      tslib: 2.8.1
 
   graphql-yoga@5.21.2(graphql@17.0.2):
     dependencies:
@@ -8514,11 +8529,15 @@ snapshots:
       lru-cache: 10.4.3
       tslib: 2.8.1
 
+  graphql@14.7.0:
+    dependencies:
+      iterall: 1.3.0
+
   graphql@17.0.2: {}
 
-  gtoken@7.1.0(encoding@0.1.13)(supports-color@8.1.1):
+  gtoken@7.1.0(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      gaxios: 6.7.1(encoding@0.1.13)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -8569,6 +8588,11 @@ snapshots:
 
   helmet@8.3.0: {}
 
+  help-me@4.2.0:
+    dependencies:
+      glob: 8.1.0
+      readable-stream: 3.6.2
+
   hoek@2.16.3: {}
 
   hosted-git-info@9.0.3:
@@ -8588,26 +8612,26 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0(supports-color@8.1.1):
+  http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.1
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -8618,17 +8642,17 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      agent-base: 6.0.2
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8682,11 +8706,11 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  ioredis@5.3.2(supports-color@8.1.1):
+  ioredis@5.3.2:
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -8762,9 +8786,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -8772,9 +8796,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
+  istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -8788,10 +8812,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
+  istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -8815,10 +8839,10 @@ snapshots:
       jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.4.2(supports-color@8.1.1):
+  jest-circus@30.4.2:
     dependencies:
       '@jest/environment': 30.4.1
-      '@jest/expect': 30.4.1(supports-color@8.1.1)
+      '@jest/expect': 30.4.1
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 22.20.0
@@ -8829,8 +8853,8 @@ snapshots:
       jest-each: 30.4.1
       jest-matcher-utils: 30.4.1
       jest-message-util: 30.4.1
-      jest-runtime: 30.4.2(supports-color@8.1.1)
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
+      jest-runtime: 30.4.2
+      jest-snapshot: 30.4.1
       jest-util: 30.4.1
       p-limit: 3.1.0
       pretty-format: 30.4.1
@@ -8841,15 +8865,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@22.20.0)(supports-color@8.1.1):
+  jest-cli@30.4.2(@types/node@22.20.0):
     dependencies:
-      '@jest/core': 30.4.2(supports-color@8.1.1)
+      '@jest/core': 30.4.2
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@22.20.0)(supports-color@8.1.1)
+      jest-config: 30.4.2(@types/node@22.20.0)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.3
@@ -8860,25 +8884,25 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@22.20.0)(supports-color@8.1.1):
+  jest-config@30.4.2(@types/node@22.20.0):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.4.0
       '@jest/test-sequencer': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 30.4.1(@babel/core@7.29.7)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
       glob: 10.5.0
       graceful-fs: 4.2.11
-      jest-circus: 30.4.2(supports-color@8.1.1)
+      jest-circus: 30.4.2
       jest-docblock: 30.4.0
       jest-environment-node: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-runner: 30.4.2(supports-color@8.1.1)
+      jest-runner: 30.4.2
       jest-util: 30.4.1
       jest-validate: 30.4.1
       parse-json: 5.2.0
@@ -9024,10 +9048,10 @@ snapshots:
 
   jest-regex-util@30.4.0: {}
 
-  jest-resolve-dependencies@30.4.2(supports-color@8.1.1):
+  jest-resolve-dependencies@30.4.2:
     dependencies:
       jest-regex-util: 30.4.0
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
+      jest-snapshot: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9042,12 +9066,12 @@ snapshots:
       slash: 3.0.0
       unrs-resolver: 1.12.2
 
-  jest-runner@30.4.2(supports-color@8.1.1):
+  jest-runner@30.4.2:
     dependencies:
       '@jest/console': 30.4.1
       '@jest/environment': 30.4.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 22.20.0
       chalk: 4.1.2
@@ -9060,7 +9084,7 @@ snapshots:
       jest-leak-detector: 30.4.1
       jest-message-util: 30.4.1
       jest-resolve: 30.4.1
-      jest-runtime: 30.4.2(supports-color@8.1.1)
+      jest-runtime: 30.4.2
       jest-util: 30.4.1
       jest-watcher: 30.4.1
       jest-worker: 30.4.1
@@ -9069,14 +9093,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@30.4.2(supports-color@8.1.1):
+  jest-runtime@30.4.2:
     dependencies:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
-      '@jest/globals': 30.4.1(supports-color@8.1.1)
+      '@jest/globals': 30.4.1
       '@jest/source-map': 30.0.1
       '@jest/test-result': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@types/node': 22.20.0
       chalk: 4.1.2
@@ -9089,24 +9113,24 @@ snapshots:
       jest-mock: 30.4.1
       jest-regex-util: 30.4.0
       jest-resolve: 30.4.1
-      jest-snapshot: 30.4.1(supports-color@8.1.1)
+      jest-snapshot: 30.4.1
       jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0(supports-color@8.1.1):
+  jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/types': 7.29.7
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@8.1.1)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -9121,19 +9145,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@30.4.1(supports-color@8.1.1):
+  jest-snapshot@30.4.1:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/types': 7.29.7
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 30.4.1
       graceful-fs: 4.2.11
@@ -9200,12 +9224,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@22.20.0)(supports-color@8.1.1):
+  jest@30.4.2(@types/node@22.20.0):
     dependencies:
-      '@jest/core': 30.4.2(supports-color@8.1.1)
+      '@jest/core': 30.4.2
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@22.20.0)(supports-color@8.1.1)
+      jest-cli: 30.4.2(@types/node@22.20.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9308,11 +9332,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libxmljs2@0.37.0(supports-color@8.1.1):
+  libxmljs2@0.37.0:
     dependencies:
       bindings: 1.5.0
       nan: 2.22.2
-      node-gyp: 11.5.0(supports-color@8.1.1)
+      node-gyp: 11.5.0
       prebuild-install: 7.1.3
     transitivePeerDependencies:
       - supports-color
@@ -9439,9 +9463,9 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@14.0.3(supports-color@8.1.1):
+  make-fetch-happen@14.0.3:
     dependencies:
-      '@npmcli/agent': 3.0.0(supports-color@8.1.1)
+      '@npmcli/agent': 3.0.0
       cacache: 19.0.1
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -9621,12 +9645,12 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-gyp@11.5.0(supports-color@8.1.1):
+  node-gyp@11.5.0:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 14.0.3(supports-color@8.1.1)
+      make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.8.5
@@ -9690,6 +9714,8 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openpgp@6.3.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -9935,9 +9961,9 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  properties-reader@3.0.1(supports-color@8.1.1):
+  properties-reader@3.0.1:
     dependencies:
-      '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
+      '@kwsites/file-exists': 1.1.1
       mkdirp: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10110,9 +10136,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2(supports-color@8.1.1):
+  require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       module-details-from-path: 1.0.4
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -10140,11 +10166,11 @@ snapshots:
 
   ret@0.2.2: {}
 
-  retry-request@7.0.2(encoding@0.1.13)(supports-color@8.1.1):
+  retry-request@7.0.2(encoding@0.1.13):
     dependencies:
       '@types/request': 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@8.1.1)
+      teeny-request: 9.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10197,9 +10223,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2(supports-color@8.1.1):
+  send@0.19.2:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -10215,12 +10241,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3(supports-color@8.1.1):
+  serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@8.1.1)
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10307,10 +10333,10 @@ snapshots:
     dependencies:
       hoek: 2.16.3
 
-  socks-proxy-agent@8.0.5(supports-color@8.1.1):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -10473,11 +10499,11 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  superagent@10.3.0(supports-color@8.1.1):
+  superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       fast-safe-stringify: 2.1.1
       form-data: 4.0.6
       formidable: 3.5.4
@@ -10487,11 +10513,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.2.2(supports-color@8.1.1):
+  supertest@7.2.2:
     dependencies:
       cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 10.3.0(supports-color@8.1.1)
+      superagent: 10.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10562,10 +10588,10 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  teeny-request@9.0.0(encoding@0.1.13)(supports-color@8.1.1):
+  teeny-request@9.0.0(encoding@0.1.13):
     dependencies:
-      http-proxy-agent: 5.0.0(supports-color@8.1.1)
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.1
@@ -10586,19 +10612,19 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  testcontainers@12.0.4(supports-color@8.1.1):
+  testcontainers@12.0.4:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
       archiver: 7.0.1
       async-lock: 1.4.1
       byline: 5.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       docker-compose: 1.4.2
-      dockerode: 5.0.1(supports-color@8.1.1)
+      dockerode: 5.0.1
       get-port: 5.1.1
       proper-lockfile: 4.1.2
-      properties-reader: 3.0.1(supports-color@8.1.1)
+      properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.3
       tmp: 0.2.7
@@ -10660,12 +10686,12 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7(supports-color@8.1.1))(@jest/transform@30.4.1(supports-color@8.1.1))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.0)(supports-color@8.1.1))(typescript@5.6.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.0))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@22.20.0)(supports-color@8.1.1)
+      jest: 30.4.2(@types/node@22.20.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -10674,10 +10700,10 @@ snapshots:
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@jest/transform': 30.4.1(supports-color@8.1.1)
+      '@babel/core': 7.29.7
+      '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 30.4.1(@babel/core@7.29.7)
       esbuild: 0.28.1
       jest-util: 30.4.1
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import { publicAttestationsRouter } from "./routes/publicAttestations.js";
 import usersRouter from "./routes/users.js";
 import { jwksManager } from "./utils/jwks.js";
 import { razorpayWebhookRouter } from "./routes/webhooks-razorpay.js";
+import { webhookEgressIpsRouter } from "./routes/webhookEgressIps.js";
 import adminRouter from "./routes/admin.js";
 import adminGraphqlRouter from "./routes/admin.graphql.js";
 import {
@@ -159,6 +160,9 @@ export function createApp(readinessReport: StartupReadinessReport): Express {
     res.set("ETag", etag)
     res.json(jwks)
   });
+
+  // Webhook egress IP allow-list (issue #534)
+  app.use(webhookEgressIpsRouter);
 
   // 5. Error Handling
   app.use(errorHandler);

--- a/src/jobs/auditSignedExport.ts
+++ b/src/jobs/auditSignedExport.ts
@@ -1,0 +1,308 @@
+/**
+ * Audit-Log Signed Export Job  (issue #580)
+ *
+ * Regulators require signed audit exports. This module:
+ *
+ *  1. Fetches all audit logs via the existing `getAllAuditLogs()` repository.
+ *  2. Builds a gzip-compressed tarball containing:
+ *       - `audit-logs.json`    – newline-delimited JSON of every log entry
+ *       - `manifest.json`      – export metadata (record count, SHA-256 of logs file)
+ *  3. Signs the manifest text with a detached PGP signature using a private key
+ *     sourced from the secret loader (`AUDIT_EXPORT_PGP_PRIVATE_KEY`).
+ *  4. Returns the tarball buffer + armored detached signature so the caller can
+ *     upload them to an encrypted bucket or attach them to a regulated report.
+ *
+ * Key rotation safety:
+ *   The signing step fetches the key fresh on every run, so a key rotation that
+ *   updates the secret loader's backing store takes effect on the next export
+ *   without any deployment. A `passphrase` may optionally be supplied via the
+ *   `AUDIT_EXPORT_PGP_PASSPHRASE` secret.
+ *
+ * The job follows the `runInstrumentedJob` pattern used across all other jobs
+ * in this codebase so metrics (duration, item count, outcome) are emitted to
+ * Pushgateway automatically.
+ */
+
+import { createGzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { Writable, PassThrough } from "node:stream";
+import { createHash } from "node:crypto";
+import * as openpgp from "openpgp";
+import { pack as tarPack } from "tar-stream";
+import { getAllAuditLogs, type AuditLog } from "../repositories/auditLogRepository.js";
+import { createSecretLoader } from "../utils/secret-loader.js";
+import { logger } from "../utils/logger.js";
+import { runInstrumentedJob, type JobOutcome } from "./jobRunner.js";
+
+export const AUDIT_EXPORT_JOB_NAME = "audit_signed_export";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AuditExportManifest {
+  /** Export format version for consumers. */
+  exportVersion: number;
+  /** ISO-8601 timestamp when the export was generated. */
+  exportedAt: string;
+  /** Total number of audit log records included. */
+  recordCount: number;
+  /** Hex SHA-256 digest of the `audit-logs.json` file contents. */
+  logsFileSha256: string;
+  /** Fingerprint of the PGP key used to sign this manifest. */
+  signingKeyFingerprint: string;
+}
+
+export interface AuditExportResult {
+  /** Gzip-compressed tarball containing audit-logs.json + manifest.json. */
+  tarballBuffer: Buffer;
+  /** Armored PGP detached signature over the manifest JSON string. */
+  manifestSignature: string;
+  /** The manifest that was signed – consumers use this to verify. */
+  manifest: AuditExportManifest;
+  /** Number of audit log records exported. */
+  recordCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise audit logs as newline-delimited JSON (NDJSON).
+ * Each line is one JSON-encoded log record.
+ */
+export function serialiseLogsAsNdjson(logs: AuditLog[]): string {
+  return logs.map((l) => JSON.stringify(l)).join("\n");
+}
+
+/**
+ * Compute SHA-256 of a UTF-8 string and return a lowercase hex digest.
+ */
+export function sha256Hex(data: string): string {
+  return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+/**
+ * Build a gzip-compressed tarball from the provided files.
+ *
+ * @param files  - Map of filename → UTF-8 content.
+ * @returns Buffer containing the `.tar.gz` bytes.
+ */
+export async function buildTarball(
+  files: Map<string, string>
+): Promise<Buffer> {
+  const tar = tarPack();
+  const gzip = createGzip();
+
+  const chunks: Buffer[] = [];
+  const collector = new Writable({
+    write(chunk: Buffer, _enc: string, cb: () => void) {
+      chunks.push(chunk);
+      cb();
+    },
+  });
+
+  // We need to pipe tar → gzip → collector and simultaneously feed files
+  // into the tar stream. Use a PassThrough so pipeline can join them.
+  const pipelinePromise = pipeline(tar, gzip, collector);
+
+  for (const [name, content] of files) {
+    const contentBuffer = Buffer.from(content, "utf8");
+    await new Promise<void>((resolve, reject) => {
+      const entry = tar.entry(
+        { name, size: contentBuffer.length },
+        (err) => {
+          if (err) reject(err);
+          else resolve();
+        }
+      );
+      entry.end(contentBuffer);
+    });
+  }
+
+  tar.finalize();
+  await pipelinePromise;
+
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Load the PGP private key from the secret loader.
+ *
+ * The secret loader key is `AUDIT_EXPORT_PGP_PRIVATE_KEY` (armored).
+ * An optional passphrase can be supplied via `AUDIT_EXPORT_PGP_PASSPHRASE`.
+ */
+export async function loadSigningKey(): Promise<openpgp.PrivateKey> {
+  const loader = createSecretLoader();
+
+  let armoredKey: string;
+  try {
+    armoredKey = await loader.get("AUDIT_EXPORT_PGP_PRIVATE_KEY");
+  } catch {
+    // Fall back to env var for local development
+    const envKey = process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+    if (!envKey) {
+      throw new Error(
+        "AUDIT_EXPORT_PGP_PRIVATE_KEY secret is not configured. " +
+          "Set it in the secret store or as an environment variable."
+      );
+    }
+    armoredKey = envKey;
+  }
+
+  let passphrase: string | undefined;
+  try {
+    passphrase = await loader.get("AUDIT_EXPORT_PGP_PASSPHRASE");
+  } catch {
+    passphrase = process.env["AUDIT_EXPORT_PGP_PASSPHRASE"];
+  }
+
+  const privateKey = await openpgp.readPrivateKey({ armoredKey });
+
+  if (passphrase) {
+    return openpgp.decryptKey({ privateKey, passphrase });
+  }
+
+  return privateKey;
+}
+
+/**
+ * Sign `text` with a detached PGP signature using the provided private key.
+ *
+ * @returns Armored PGP signature string.
+ */
+export async function signManifest(
+  text: string,
+  privateKey: openpgp.PrivateKey
+): Promise<string> {
+  const message = await openpgp.createMessage({ text });
+  const detachedSignature = await openpgp.sign({
+    message,
+    signingKeys: privateKey,
+    detached: true,
+  });
+  return detachedSignature as string;
+}
+
+/**
+ * Verify that a detached PGP signature over `text` is valid.
+ *
+ * @param text          - The original signed text.
+ * @param armoredSig    - Armored detached PGP signature.
+ * @param publicKey     - The public key to verify against.
+ * @returns `true` if at least one valid signature is found.
+ */
+export async function verifyExportSignature(
+  text: string,
+  armoredSig: string,
+  publicKey: openpgp.PublicKey
+): Promise<boolean> {
+  try {
+    const message = await openpgp.createMessage({ text });
+    const signature = await openpgp.readSignature({ armoredSignature: armoredSig });
+    const result = await openpgp.verify({
+      message,
+      signature,
+      verificationKeys: publicKey,
+    });
+    const { verified } = result.signatures[0];
+    await verified;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core export function
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a signed audit-log export.
+ *
+ * Fetches all audit logs, builds a tarball, signs the manifest, and returns
+ * the complete export result.  Throws on configuration or signing errors so
+ * `runInstrumentedJob` can record the failure metric.
+ *
+ * @param now - Injectable clock (defaults to `new Date()`).
+ */
+export async function generateSignedAuditExport(
+  now: Date = new Date()
+): Promise<AuditExportResult> {
+  // 1. Fetch logs
+  const logs = await getAllAuditLogs();
+  const ndjson = serialiseLogsAsNdjson(logs);
+  const logsHash = sha256Hex(ndjson);
+
+  // 2. Load signing key
+  const privateKey = await loadSigningKey();
+  const fingerprint = privateKey.getFingerprint();
+
+  // 3. Build manifest
+  const manifest: AuditExportManifest = {
+    exportVersion: 1,
+    exportedAt: now.toISOString(),
+    recordCount: logs.length,
+    logsFileSha256: logsHash,
+    signingKeyFingerprint: fingerprint,
+  };
+  const manifestJson = JSON.stringify(manifest, null, 2);
+
+  // 4. Build tarball
+  const files = new Map<string, string>([
+    ["audit-logs.json", ndjson],
+    ["manifest.json", manifestJson],
+  ]);
+  const tarballBuffer = await buildTarball(files);
+
+  // 5. Sign the manifest
+  const manifestSignature = await signManifest(manifestJson, privateKey);
+
+  return {
+    tarballBuffer,
+    manifestSignature,
+    manifest,
+    recordCount: logs.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Job entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Scheduled audit-log signed export job.
+ *
+ * Intended to run nightly (or on-demand via admin trigger). Generates a signed
+ * export and logs the result.  In production the caller should upload
+ * `tarballBuffer` and `manifestSignature` to the encrypted S3/GCS bucket.
+ *
+ * @param now - Injectable clock for deterministic testing.
+ */
+export const auditSignedExportJob = async (
+  now: Date = new Date()
+): Promise<JobOutcome> => {
+  return runInstrumentedJob(AUDIT_EXPORT_JOB_NAME, async () => {
+    logger.info("Running audit signed export job…");
+
+    try {
+      const result = await generateSignedAuditExport(now);
+
+      logger.info(
+        {
+          recordCount: result.recordCount,
+          tarballBytes: result.tarballBuffer.length,
+          exportedAt: result.manifest.exportedAt,
+          signingKeyFingerprint: result.manifest.signingKeyFingerprint,
+        },
+        "Audit export generated. Upload tarball + signature to encrypted bucket."
+      );
+
+      return { itemsProcessed: result.recordCount, success: true };
+    } catch (error) {
+      logger.error("Audit signed export job failed", error);
+      return { itemsProcessed: 0, success: false };
+    }
+  });
+};

--- a/src/routes/webhookEgressIps.ts
+++ b/src/routes/webhookEgressIps.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /.well-known/webhook-egress-ips
+ *
+ * Machine-readable, HMAC-signed manifest of the NAT egress IPs Veritasor uses
+ * when dispatching outbound webhooks.  Enterprise tenants consume this endpoint
+ * to keep their firewall allow-lists in sync.
+ *
+ * Response shape (JSON):
+ * ```json
+ * {
+ *   "manifest": {
+ *     "version": 1,
+ *     "ips": ["203.0.113.10", "203.0.113.11"],
+ *     "signedAt": "2026-07-28T08:00:00.000Z"
+ *   },
+ *   "signature": "<hex-hmac-sha256>",
+ *   "algorithm": "hmac-sha256"
+ * }
+ * ```
+ *
+ * Verification recipe for consumers:
+ *  1. Compute `HMAC-SHA256` over the canonical JSON of `manifest`
+ *     (keys sorted alphabetically, ips array sorted).
+ *  2. Compare with `signature` using a constant-time comparison.
+ *  3. Reject manifests where `signedAt` is older than your acceptable staleness
+ *     window (e.g. 2 × Cache-Control max-age).
+ *
+ * Caching:
+ *  The response carries a `Cache-Control: public, max-age=3600` header so CDN
+ *  edges and enterprise proxies can cache it without hitting the origin for
+ *  every firewall refresh cycle.
+ */
+
+import { Router, Request, Response } from "express";
+import {
+  getSignedManifest,
+  MANIFEST_CACHE_TTL_SECONDS,
+} from "../services/webhooks/egressIpAllowList.js";
+import { logger } from "../utils/logger.js";
+
+export const webhookEgressIpsRouter = Router();
+
+webhookEgressIpsRouter.get(
+  "/.well-known/webhook-egress-ips",
+  async (_req: Request, res: Response): Promise<void> => {
+    try {
+      const signed = await getSignedManifest();
+
+      res.set(
+        "Cache-Control",
+        `public, max-age=${MANIFEST_CACHE_TTL_SECONDS}, stale-while-revalidate=60`
+      );
+      res.set("Content-Type", "application/json; charset=utf-8");
+
+      res.json(signed);
+    } catch (err) {
+      logger.error("Failed to generate webhook egress IP manifest", err);
+      res.status(500).json({
+        status: "error",
+        code: "MANIFEST_GENERATION_FAILED",
+        message: "Unable to generate egress IP manifest",
+      });
+    }
+  }
+);

--- a/src/services/webhooks/egressIpAllowList.ts
+++ b/src/services/webhooks/egressIpAllowList.ts
@@ -1,0 +1,186 @@
+/**
+ * Webhook Egress IP Allow-List  (issue #534)
+ *
+ * Enterprise consumers need a stable, machine-readable list of source IPs that
+ * Veritasor uses when dispatching outbound webhooks.  This module:
+ *
+ *  1. Maintains the canonical IP list and a monotonic manifest version.
+ *  2. Produces a signed manifest (HMAC-SHA256 over a canonical JSON payload)
+ *     so consumers can verify authenticity without a public PKI dependency.
+ *  3. Exposes `getSignedManifest()` consumed by the /.well-known endpoint.
+ *
+ * Rotation:
+ *   Update `WEBHOOK_EGRESS_IPS` and bump `MANIFEST_VERSION`.  The signing key
+ *   is loaded via the shared SecretAdapter so it can be rotated through the
+ *   same Vault / AWS-SM / GSM pipelines used for all other secrets.
+ *
+ * Security notes:
+ *  • The signing key should be at least 32 bytes of random data.
+ *  • The manifest payload is deterministically serialised (keys sorted) so the
+ *    signature is stable for a given set of IPs + version.
+ *  • `signedAt` is included in the signed payload so replay of an old manifest
+ *    can be detected by comparing the timestamp to the present time.
+ */
+
+import crypto from "node:crypto";
+import { createSecretLoader } from "../../utils/secret-loader.js";
+import { logger } from "../../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Known NAT egress IPs for outbound webhook traffic.
+ *
+ * Operators: update this list (and bump MANIFEST_VERSION) whenever IP
+ * allocation changes.  The list is sorted for deterministic serialisation.
+ */
+export const WEBHOOK_EGRESS_IPS: readonly string[] = Object.freeze([
+  "203.0.113.10",
+  "203.0.113.11",
+  "203.0.113.12",
+]);
+
+/**
+ * Monotonic version number for the manifest.  Increment whenever IPs are
+ * added, removed, or changed so consumers can detect staleness.
+ */
+export const MANIFEST_VERSION = 1;
+
+/**
+ * Cache TTL in seconds advertised to HTTP caches via Cache-Control.
+ * Consumers should re-fetch before this window expires.
+ */
+export const MANIFEST_CACHE_TTL_SECONDS = 3600; // 1 hour
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EgressIpManifest {
+  /** Monotonic version – bump on every IP list change. */
+  version: number;
+  /** Sorted list of CIDR or IPv4 addresses used as webhook egress IPs. */
+  ips: string[];
+  /** ISO-8601 timestamp when this manifest was generated. */
+  signedAt: string;
+}
+
+export interface SignedEgressIpManifest {
+  manifest: EgressIpManifest;
+  /**
+   * Hex-encoded HMAC-SHA256 over the canonical JSON serialisation of
+   * `manifest` (keys sorted, no extra whitespace).
+   */
+  signature: string;
+  /** Algorithm identifier – always "hmac-sha256" for this implementation. */
+  algorithm: "hmac-sha256";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a canonical (stable) JSON string from the manifest.
+ *
+ * Keys are sorted to ensure the serialisation is deterministic regardless of
+ * insertion order, so the HMAC remains stable for a given logical manifest.
+ */
+export function canonicaliseManifest(manifest: EgressIpManifest): string {
+  // Sort ips list for determinism
+  const stable: EgressIpManifest = {
+    ips: [...manifest.ips].sort(),
+    signedAt: manifest.signedAt,
+    version: manifest.version,
+  };
+  return JSON.stringify(stable, Object.keys(stable).sort());
+}
+
+/**
+ * Compute HMAC-SHA256 signature over `data` using `signingKey`.
+ */
+export function computeManifestSignature(
+  data: string,
+  signingKey: string
+): string {
+  return crypto.createHmac("sha256", signingKey).update(data).digest("hex");
+}
+
+/**
+ * Verify that a `SignedEgressIpManifest` carries a valid signature.
+ *
+ * @param signed       - The manifest + signature to verify.
+ * @param signingKey   - The HMAC key used when the manifest was signed.
+ * @returns `true` if the signature is valid; `false` otherwise.
+ */
+export function verifyManifestSignature(
+  signed: SignedEgressIpManifest,
+  signingKey: string
+): boolean {
+  const canonical = canonicaliseManifest(signed.manifest);
+  const expected = computeManifestSignature(canonical, signingKey);
+  const expectedBuf = Buffer.from(expected, "hex");
+  let providedBuf: Buffer;
+  try {
+    providedBuf = Buffer.from(signed.signature, "hex");
+  } catch {
+    return false;
+  }
+  if (expectedBuf.length !== providedBuf.length) return false;
+  return crypto.timingSafeEqual(expectedBuf, providedBuf);
+}
+
+// ---------------------------------------------------------------------------
+// Primary API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build and sign the current egress IP manifest.
+ *
+ * The signing key is sourced from the secret loader under the key
+ * `WEBHOOK_EGRESS_SIGNING_KEY`.  In production this should be a random
+ * 256-bit hex string; in development the loader falls back to the env var of
+ * the same name.
+ *
+ * @param now - Injectable clock (defaults to `new Date()`).
+ */
+export async function getSignedManifest(
+  now: Date = new Date()
+): Promise<SignedEgressIpManifest> {
+  const loader = createSecretLoader();
+  let signingKey: string;
+
+  try {
+    signingKey = await loader.get("WEBHOOK_EGRESS_SIGNING_KEY");
+  } catch {
+    // Fall back to a dev-only placeholder so local development still works;
+    // production deployments must supply the secret.
+    const fallback = process.env["WEBHOOK_EGRESS_SIGNING_KEY"];
+    if (fallback) {
+      signingKey = fallback;
+    } else {
+      logger.warn(
+        "WEBHOOK_EGRESS_SIGNING_KEY not configured – using insecure fallback. " +
+          "Set this secret in production."
+      );
+      signingKey = "dev-insecure-signing-key-do-not-use-in-production";
+    }
+  }
+
+  const manifest: EgressIpManifest = {
+    version: MANIFEST_VERSION,
+    ips: [...WEBHOOK_EGRESS_IPS].sort(),
+    signedAt: now.toISOString(),
+  };
+
+  const canonical = canonicaliseManifest(manifest);
+  const signature = computeManifestSignature(canonical, signingKey);
+
+  return {
+    manifest,
+    signature,
+    algorithm: "hmac-sha256",
+  };
+}

--- a/tests/unit/jobs/auditSignedExport.test.ts
+++ b/tests/unit/jobs/auditSignedExport.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Tests for audit-log signed export job (issue #580)
+ *
+ * Coverage targets:
+ *  - serialiseLogsAsNdjson: correct NDJSON output
+ *  - sha256Hex: correct SHA-256 digest
+ *  - buildTarball: produces valid gzip-compressed tar archive
+ *  - loadSigningKey: secret loader + env fallback + error
+ *  - signManifest: produces valid armored PGP signature
+ *  - verifyExportSignature: accept/reject paths
+ *  - generateSignedAuditExport: full flow, clock injection, key rotation
+ *  - auditSignedExportJob: job runner integration, success/failure metrics
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import * as openpgp from "openpgp";
+import { gunzipSync } from "node:zlib";
+
+// ---------------------------------------------------------------------------
+// Mocks – must come before subject imports
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../src/utils/secret-loader.js", () => ({
+  createSecretLoader: vi.fn(),
+}));
+
+vi.mock("../../../src/repositories/auditLogRepository.js", () => ({
+  getAllAuditLogs: vi.fn(),
+}));
+
+// Mock jobRunner to avoid Pushgateway calls during unit tests
+vi.mock("../../../src/jobs/jobRunner.js", () => ({
+  runInstrumentedJob: vi.fn(
+    (_name: string, fn: () => Promise<unknown>) => fn()
+  ),
+}));
+
+import { createSecretLoader } from "../../../src/utils/secret-loader.js";
+import { getAllAuditLogs } from "../../../src/repositories/auditLogRepository.js";
+import {
+  serialiseLogsAsNdjson,
+  sha256Hex,
+  buildTarball,
+  loadSigningKey,
+  signManifest,
+  verifyExportSignature,
+  generateSignedAuditExport,
+  auditSignedExportJob,
+  AUDIT_EXPORT_JOB_NAME,
+} from "../../../src/jobs/auditSignedExport.js";
+import type { AuditLog } from "../../../src/repositories/auditLogRepository.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeLog(overrides: Partial<AuditLog> = {}): AuditLog {
+  return {
+    id: "log-001",
+    userId: "user-abc",
+    action: "login",
+    resource: "auth",
+    resourceId: "session-001",
+    metadata: { ip: "127.0.0.1" },
+    contentHash: undefined,
+    timestamp: new Date("2026-07-28T08:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// serialiseLogsAsNdjson
+// ---------------------------------------------------------------------------
+
+describe("serialiseLogsAsNdjson", () => {
+  it("returns an empty string for empty input", () => {
+    expect(serialiseLogsAsNdjson([])).toBe("");
+  });
+
+  it("serialises a single log as one line of JSON", () => {
+    const log = makeLog();
+    const result = serialiseLogsAsNdjson([log]);
+    const parsed = JSON.parse(result);
+    expect(parsed.id).toBe(log.id);
+  });
+
+  it("separates multiple logs with newlines", () => {
+    const logs = [makeLog({ id: "a" }), makeLog({ id: "b" })];
+    const result = serialiseLogsAsNdjson(logs);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).id).toBe("a");
+    expect(JSON.parse(lines[1]).id).toBe("b");
+  });
+
+  it("serialises the timestamp as a string (JSON.stringify behaviour)", () => {
+    const log = makeLog();
+    const result = serialiseLogsAsNdjson([log]);
+    const parsed = JSON.parse(result);
+    expect(typeof parsed.timestamp).toBe("string");
+  });
+
+  it("includes all fields including metadata", () => {
+    const log = makeLog({ metadata: { foo: "bar", n: 42 } });
+    const result = serialiseLogsAsNdjson([log]);
+    const parsed = JSON.parse(result);
+    expect(parsed.metadata).toEqual({ foo: "bar", n: 42 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sha256Hex
+// ---------------------------------------------------------------------------
+
+describe("sha256Hex", () => {
+  it("returns a 64-char lowercase hex string", () => {
+    expect(sha256Hex("hello")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns the well-known SHA-256 of 'hello'", () => {
+    // echo -n 'hello' | sha256sum
+    expect(sha256Hex("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+  });
+
+  it("returns different hashes for different inputs", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+
+  it("is deterministic", () => {
+    expect(sha256Hex("test")).toBe(sha256Hex("test"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTarball
+// ---------------------------------------------------------------------------
+
+describe("buildTarball", () => {
+  it("returns a non-empty Buffer", async () => {
+    const files = new Map([["hello.txt", "hello world"]]);
+    const buf = await buildTarball(files);
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it("produces valid gzip data (starts with gzip magic bytes 0x1f 0x8b)", async () => {
+    const files = new Map([["a.json", '{"test":true}']]);
+    const buf = await buildTarball(files);
+    expect(buf[0]).toBe(0x1f);
+    expect(buf[1]).toBe(0x8b);
+  });
+
+  it("produces data that can be gunzipped without error", async () => {
+    const files = new Map([["test.txt", "content here"]]);
+    const buf = await buildTarball(files);
+    expect(() => gunzipSync(buf)).not.toThrow();
+  });
+
+  it("handles multiple files", async () => {
+    const files = new Map([
+      ["file1.txt", "content one"],
+      ["file2.json", '{"key":"value"}'],
+      ["file3.csv", "a,b,c\n1,2,3"],
+    ]);
+    const buf = await buildTarball(files);
+    expect(buf.length).toBeGreaterThan(0);
+    expect(buf[0]).toBe(0x1f);
+  });
+
+  it("handles empty files map (empty tarball)", async () => {
+    const files = new Map<string, string>();
+    const buf = await buildTarball(files);
+    // Even empty tar produces valid gzip
+    expect(buf[0]).toBe(0x1f);
+    expect(buf[1]).toBe(0x8b);
+  });
+
+  it("handles unicode content", async () => {
+    const files = new Map([["unicode.txt", "日本語テスト 🔐"]]);
+    const buf = await buildTarball(files);
+    expect(() => gunzipSync(buf)).not.toThrow();
+  });
+
+  it("produces larger output for larger content", async () => {
+    const small = new Map([["s.txt", "small"]]);
+    const large = new Map([["l.txt", "x".repeat(10_000)]]);
+    const smallBuf = await buildTarball(small);
+    const largeBuf = await buildTarball(large);
+    expect(largeBuf.length).toBeGreaterThan(smallBuf.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSigningKey
+// ---------------------------------------------------------------------------
+
+describe("loadSigningKey", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("throws when neither loader nor env has the PGP key", async () => {
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockRejectedValue(new Error("not found")),
+      reload: vi.fn(),
+    });
+    const old = process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+    delete process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+
+    try {
+      await expect(loadSigningKey()).rejects.toThrow(
+        "AUDIT_EXPORT_PGP_PRIVATE_KEY secret is not configured"
+      );
+    } finally {
+      if (old !== undefined) process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"] = old;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signManifest + verifyExportSignature – using freshly generated keys
+// ---------------------------------------------------------------------------
+
+describe("signManifest / verifyExportSignature", () => {
+  let privateKey: openpgp.PrivateKey;
+  let publicKey: openpgp.PublicKey;
+
+  beforeAll(async () => {
+    const keypair = await openpgp.generateKey({
+      type: "rsa",
+      rsaBits: 2048,
+      userIDs: [{ name: "Test", email: "test@veritasor.test" }],
+    });
+    privateKey = await openpgp.readPrivateKey({ armoredKey: keypair.privateKey });
+    publicKey = await openpgp.readKey({ armoredKey: keypair.publicKey });
+  });
+
+  it("signManifest returns an armored PGP signature string", async () => {
+    const text = '{"exportVersion":1,"recordCount":5}';
+    const sig = await signManifest(text, privateKey);
+    expect(sig).toContain("-----BEGIN PGP SIGNATURE-----");
+    expect(sig).toContain("-----END PGP SIGNATURE-----");
+  });
+
+  it("verifyExportSignature returns true for a valid signature", async () => {
+    const text = '{"hello":"world"}';
+    const sig = await signManifest(text, privateKey);
+    const valid = await verifyExportSignature(text, sig, publicKey);
+    expect(valid).toBe(true);
+  });
+
+  it("verifyExportSignature returns false for a tampered message", async () => {
+    const text = '{"hello":"world"}';
+    const sig = await signManifest(text, privateKey);
+    const valid = await verifyExportSignature(text + " tampered", sig, publicKey);
+    expect(valid).toBe(false);
+  });
+
+  it("verifyExportSignature returns false for a different public key", async () => {
+    const text = "test message";
+    const sig = await signManifest(text, privateKey);
+
+    const other = await openpgp.generateKey({
+      type: "rsa",
+      rsaBits: 2048,
+      userIDs: [{ name: "Other", email: "other@veritasor.test" }],
+    });
+    const otherPub = await openpgp.readKey({ armoredKey: other.publicKey });
+
+    const valid = await verifyExportSignature(text, sig, otherPub);
+    expect(valid).toBe(false);
+  });
+
+  it("verifyExportSignature returns false for a garbage signature", async () => {
+    const valid = await verifyExportSignature(
+      "anything",
+      "not-a-pgp-signature",
+      publicKey
+    );
+    expect(valid).toBe(false);
+  });
+
+  it("two signatures over the same text both verify successfully", async () => {
+    const text = "same text";
+    const sig1 = await signManifest(text, privateKey);
+    const sig2 = await signManifest(text, privateKey);
+    const [v1, v2] = await Promise.all([
+      verifyExportSignature(text, sig1, publicKey),
+      verifyExportSignature(text, sig2, publicKey),
+    ]);
+    expect(v1).toBe(true);
+    expect(v2).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateSignedAuditExport – full flow
+// ---------------------------------------------------------------------------
+
+describe("generateSignedAuditExport", () => {
+  let privateKeyArmored: string;
+  let publicKeyObj: openpgp.PublicKey;
+
+  beforeAll(async () => {
+    const keypair = await openpgp.generateKey({
+      type: "rsa",
+      rsaBits: 2048,
+      userIDs: [{ name: "Veritasor CI", email: "ci@veritasor.test" }],
+    });
+    privateKeyArmored = keypair.privateKey;
+    publicKeyObj = await openpgp.readKey({ armoredKey: keypair.publicKey });
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockImplementation(async (key: string) => {
+        if (key === "AUDIT_EXPORT_PGP_PRIVATE_KEY") return privateKeyArmored;
+        throw new Error("secret not found: " + key);
+      }),
+      reload: vi.fn(),
+    });
+    vi.mocked(getAllAuditLogs).mockResolvedValue([]);
+  });
+
+  it("returns AuditExportResult with correct shape", async () => {
+    const result = await generateSignedAuditExport();
+    expect(result).toMatchObject({
+      tarballBuffer: expect.any(Buffer),
+      manifestSignature: expect.any(String),
+      manifest: expect.objectContaining({
+        exportVersion: 1,
+        exportedAt: expect.any(String),
+        recordCount: 0,
+        logsFileSha256: expect.any(String),
+        signingKeyFingerprint: expect.any(String),
+      }),
+      recordCount: 0,
+    });
+  });
+
+  it("uses injectable clock for exportedAt", async () => {
+    const fixed = new Date("2026-07-28T12:00:00.000Z");
+    const result = await generateSignedAuditExport(fixed);
+    expect(result.manifest.exportedAt).toBe("2026-07-28T12:00:00.000Z");
+  });
+
+  it("reflects record count from fetched logs", async () => {
+    const logs = [makeLog({ id: "a" }), makeLog({ id: "b" }), makeLog({ id: "c" })];
+    vi.mocked(getAllAuditLogs).mockResolvedValue(logs);
+
+    const result = await generateSignedAuditExport();
+    expect(result.recordCount).toBe(3);
+    expect(result.manifest.recordCount).toBe(3);
+  });
+
+  it("logsFileSha256 matches sha256 of the serialised NDJSON", async () => {
+    const logs = [makeLog()];
+    vi.mocked(getAllAuditLogs).mockResolvedValue(logs);
+
+    const result = await generateSignedAuditExport();
+    const expectedHash = sha256Hex(serialiseLogsAsNdjson(logs));
+    expect(result.manifest.logsFileSha256).toBe(expectedHash);
+  });
+
+  it("tarball buffer starts with valid gzip magic bytes", async () => {
+    const result = await generateSignedAuditExport();
+    expect(result.tarballBuffer[0]).toBe(0x1f);
+    expect(result.tarballBuffer[1]).toBe(0x8b);
+  });
+
+  it("manifest signature passes PGP verification with the public key", async () => {
+    vi.mocked(getAllAuditLogs).mockResolvedValue([makeLog()]);
+    const result = await generateSignedAuditExport();
+
+    const manifestJson = JSON.stringify(result.manifest, null, 2);
+    const valid = await verifyExportSignature(
+      manifestJson,
+      result.manifestSignature,
+      publicKeyObj
+    );
+    expect(valid).toBe(true);
+  });
+
+  it("manifestSignature is in PGP armored format", async () => {
+    const result = await generateSignedAuditExport();
+    expect(result.manifestSignature).toContain("-----BEGIN PGP SIGNATURE-----");
+    expect(result.manifestSignature).toContain("-----END PGP SIGNATURE-----");
+  });
+
+  it("throws when PGP key is not configured", async () => {
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockRejectedValue(new Error("not found")),
+      reload: vi.fn(),
+    });
+    const old = process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+    delete process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+
+    try {
+      await expect(generateSignedAuditExport()).rejects.toThrow();
+    } finally {
+      if (old !== undefined) process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"] = old;
+    }
+  });
+
+  it("uses env var fallback when secret loader throws", async () => {
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockRejectedValue(new Error("vault unavailable")),
+      reload: vi.fn(),
+    });
+    process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"] = privateKeyArmored;
+
+    try {
+      const result = await generateSignedAuditExport();
+      expect(result.tarballBuffer.length).toBeGreaterThan(0);
+    } finally {
+      delete process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+    }
+  });
+
+  it("fetches the signing key fresh on each call (key rotation safety)", async () => {
+    let getCallCount = 0;
+    vi.mocked(createSecretLoader).mockImplementation(() => ({
+      get: vi.fn().mockImplementation(async (key: string) => {
+        if (key === "AUDIT_EXPORT_PGP_PRIVATE_KEY") {
+          getCallCount++;
+          return privateKeyArmored;
+        }
+        throw new Error("not found");
+      }),
+      reload: vi.fn(),
+    }));
+
+    await generateSignedAuditExport();
+    await generateSignedAuditExport();
+
+    // Each call should have fetched the key at least once
+    expect(getCallCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditSignedExportJob – job runner integration
+// ---------------------------------------------------------------------------
+
+describe("auditSignedExportJob", () => {
+  let privateKeyArmored: string;
+
+  beforeAll(async () => {
+    const keypair = await openpgp.generateKey({
+      type: "rsa",
+      rsaBits: 2048,
+      userIDs: [{ name: "Job Test", email: "job@veritasor.test" }],
+    });
+    privateKeyArmored = keypair.privateKey;
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockImplementation(async (key: string) => {
+        if (key === "AUDIT_EXPORT_PGP_PRIVATE_KEY") return privateKeyArmored;
+        throw new Error("not found");
+      }),
+      reload: vi.fn(),
+    });
+  });
+
+  it("returns success:true and itemsProcessed matching log count", async () => {
+    const logs = [makeLog({ id: "a" }), makeLog({ id: "b" })];
+    vi.mocked(getAllAuditLogs).mockResolvedValue(logs);
+
+    const outcome = await auditSignedExportJob();
+    expect(outcome.success).toBe(true);
+    expect(outcome.itemsProcessed).toBe(2);
+  });
+
+  it("returns success:false when signing key is missing", async () => {
+    vi.mocked(createSecretLoader).mockReturnValue({
+      get: vi.fn().mockRejectedValue(new Error("not found")),
+      reload: vi.fn(),
+    });
+    const old = process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+    delete process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"];
+
+    try {
+      vi.mocked(getAllAuditLogs).mockResolvedValue([]);
+      const outcome = await auditSignedExportJob();
+      expect(outcome.success).toBe(false);
+      expect(outcome.itemsProcessed).toBe(0);
+    } finally {
+      if (old !== undefined) process.env["AUDIT_EXPORT_PGP_PRIVATE_KEY"] = old;
+    }
+  });
+
+  it("returns success:false when getAllAuditLogs throws", async () => {
+    vi.mocked(getAllAuditLogs).mockRejectedValue(new Error("db failure"));
+
+    const outcome = await auditSignedExportJob();
+    expect(outcome.success).toBe(false);
+    expect(outcome.itemsProcessed).toBe(0);
+  });
+
+  it("AUDIT_EXPORT_JOB_NAME constant is 'audit_signed_export'", () => {
+    expect(AUDIT_EXPORT_JOB_NAME).toBe("audit_signed_export");
+  });
+
+  it("accepts an injectable clock parameter", async () => {
+    vi.mocked(getAllAuditLogs).mockResolvedValue([makeLog()]);
+    const fixed = new Date("2026-07-28T00:00:00.000Z");
+    const outcome = await auditSignedExportJob(fixed);
+    expect(outcome.success).toBe(true);
+  });
+
+  it("handles empty audit log store gracefully", async () => {
+    vi.mocked(getAllAuditLogs).mockResolvedValue([]);
+    const outcome = await auditSignedExportJob();
+    expect(outcome.success).toBe(true);
+    expect(outcome.itemsProcessed).toBe(0);
+  });
+});

--- a/tests/unit/services/webhooks/egressIpAllowList.test.ts
+++ b/tests/unit/services/webhooks/egressIpAllowList.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for webhook egress IP allow-list (issue #534)
+ *
+ * Coverage targets:
+ *  - canonicaliseManifest: deterministic serialisation
+ *  - computeManifestSignature: HMAC correctness
+ *  - verifyManifestSignature: accept/reject paths + timing-safe compare
+ *  - getSignedManifest: signed payload shape, key fallback, clock injection
+ *  - GET /.well-known/webhook-egress-ips: HTTP contract, caching headers, 500 path
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Mock the secret loader so tests run without real secret infrastructure
+// ---------------------------------------------------------------------------
+vi.mock("../../../../src/utils/secret-loader.js", () => ({
+  createSecretLoader: vi.fn(),
+}));
+
+import { createSecretLoader } from "../../../../src/utils/secret-loader.js";
+import {
+  canonicaliseManifest,
+  computeManifestSignature,
+  verifyManifestSignature,
+  getSignedManifest,
+  WEBHOOK_EGRESS_IPS,
+  MANIFEST_VERSION,
+  MANIFEST_CACHE_TTL_SECONDS,
+  type EgressIpManifest,
+  type SignedEgressIpManifest,
+} from "../../../../src/services/webhooks/egressIpAllowList.js";
+
+const SIGNING_KEY = "test-signing-key-for-webhook-egress-hmac-sha256-32b!";
+
+function mockLoader(key: string): void {
+  vi.mocked(createSecretLoader).mockReturnValue({
+    get: vi.fn().mockResolvedValue(key),
+    reload: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function mockLoaderThrows(): void {
+  vi.mocked(createSecretLoader).mockReturnValue({
+    get: vi.fn().mockRejectedValue(new Error("secret not found")),
+    reload: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// canonicaliseManifest
+// ---------------------------------------------------------------------------
+
+describe("canonicaliseManifest", () => {
+  const base: EgressIpManifest = {
+    version: 1,
+    ips: ["203.0.113.12", "203.0.113.10", "203.0.113.11"],
+    signedAt: "2026-07-28T08:00:00.000Z",
+  };
+
+  it("produces valid JSON", () => {
+    const result = canonicaliseManifest(base);
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it("sorts the ips array ascending", () => {
+    const result = JSON.parse(canonicaliseManifest(base));
+    expect(result.ips).toEqual([
+      "203.0.113.10",
+      "203.0.113.11",
+      "203.0.113.12",
+    ]);
+  });
+
+  it("is idempotent – calling twice with same input returns same string", () => {
+    expect(canonicaliseManifest(base)).toBe(canonicaliseManifest(base));
+  });
+
+  it("is deterministic regardless of ip insertion order", () => {
+    const reversed: EgressIpManifest = {
+      ...base,
+      ips: ["203.0.113.11", "203.0.113.12", "203.0.113.10"],
+    };
+    expect(canonicaliseManifest(base)).toBe(canonicaliseManifest(reversed));
+  });
+
+  it("changes output when version changes", () => {
+    const v2 = { ...base, version: 2 };
+    expect(canonicaliseManifest(base)).not.toBe(canonicaliseManifest(v2));
+  });
+
+  it("changes output when signedAt changes", () => {
+    const later = { ...base, signedAt: "2026-07-29T00:00:00.000Z" };
+    expect(canonicaliseManifest(base)).not.toBe(canonicaliseManifest(later));
+  });
+
+  it("changes output when an IP is added", () => {
+    const extra = { ...base, ips: [...base.ips, "10.0.0.1"] };
+    expect(canonicaliseManifest(base)).not.toBe(canonicaliseManifest(extra));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeManifestSignature
+// ---------------------------------------------------------------------------
+
+describe("computeManifestSignature", () => {
+  const data = '{"ips":["203.0.113.10"],"signedAt":"2026-07-28T00:00:00.000Z","version":1}';
+
+  it("returns a 64-char hex string (SHA-256 = 32 bytes = 64 hex chars)", () => {
+    const sig = computeManifestSignature(data, SIGNING_KEY);
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same value as a manual HMAC-SHA256", () => {
+    const expected = crypto
+      .createHmac("sha256", SIGNING_KEY)
+      .update(data)
+      .digest("hex");
+    expect(computeManifestSignature(data, SIGNING_KEY)).toBe(expected);
+  });
+
+  it("differs with a different key", () => {
+    expect(computeManifestSignature(data, SIGNING_KEY)).not.toBe(
+      computeManifestSignature(data, "other-key")
+    );
+  });
+
+  it("differs with a different payload", () => {
+    expect(computeManifestSignature(data, SIGNING_KEY)).not.toBe(
+      computeManifestSignature(data + " ", SIGNING_KEY)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyManifestSignature
+// ---------------------------------------------------------------------------
+
+describe("verifyManifestSignature", () => {
+  const manifest: EgressIpManifest = {
+    version: 1,
+    ips: ["203.0.113.10", "203.0.113.11"],
+    signedAt: "2026-07-28T08:00:00.000Z",
+  };
+
+  function makeSigned(m: EgressIpManifest, key: string): SignedEgressIpManifest {
+    const canonical = canonicaliseManifest(m);
+    const signature = computeManifestSignature(canonical, key);
+    return { manifest: m, signature, algorithm: "hmac-sha256" };
+  }
+
+  it("accepts a correctly signed manifest", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    expect(verifyManifestSignature(signed, SIGNING_KEY)).toBe(true);
+  });
+
+  it("rejects a manifest with a tampered signature", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const tampered: SignedEgressIpManifest = {
+      ...signed,
+      signature: "deadbeef" + signed.signature.slice(8),
+    };
+    expect(verifyManifestSignature(tampered, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects a manifest signed with a different key", () => {
+    const signed = makeSigned(manifest, "wrong-key-entirely");
+    expect(verifyManifestSignature(signed, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects when the manifest ips have been modified after signing", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const tampered: SignedEgressIpManifest = {
+      ...signed,
+      manifest: { ...signed.manifest, ips: [...signed.manifest.ips, "1.2.3.4"] },
+    };
+    expect(verifyManifestSignature(tampered, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects when the version is bumped after signing", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const tampered: SignedEgressIpManifest = {
+      ...signed,
+      manifest: { ...signed.manifest, version: 99 },
+    };
+    expect(verifyManifestSignature(tampered, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects when signedAt is modified after signing", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const tampered: SignedEgressIpManifest = {
+      ...signed,
+      manifest: { ...signed.manifest, signedAt: "2025-01-01T00:00:00.000Z" },
+    };
+    expect(verifyManifestSignature(tampered, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects a non-hex signature gracefully without throwing", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const invalid: SignedEgressIpManifest = {
+      ...signed,
+      signature: "not-hex-$$$###",
+    };
+    // Buffer.from('not-hex', 'hex') returns empty buffer, lengths differ
+    expect(verifyManifestSignature(invalid, SIGNING_KEY)).toBe(false);
+  });
+
+  it("rejects an empty signature", () => {
+    const signed = makeSigned(manifest, SIGNING_KEY);
+    const invalid: SignedEgressIpManifest = { ...signed, signature: "" };
+    expect(verifyManifestSignature(invalid, SIGNING_KEY)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSignedManifest
+// ---------------------------------------------------------------------------
+
+describe("getSignedManifest", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns a signed manifest with correct shape", async () => {
+    mockLoader(SIGNING_KEY);
+    const result = await getSignedManifest();
+
+    expect(result.algorithm).toBe("hmac-sha256");
+    expect(result.signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.manifest).toMatchObject({
+      version: MANIFEST_VERSION,
+      ips: expect.any(Array),
+      signedAt: expect.any(String),
+    });
+  });
+
+  it("includes all configured egress IPs, sorted", async () => {
+    mockLoader(SIGNING_KEY);
+    const result = await getSignedManifest();
+
+    const sorted = [...WEBHOOK_EGRESS_IPS].sort();
+    expect(result.manifest.ips).toEqual(sorted);
+  });
+
+  it("embeds the injectable clock as signedAt", async () => {
+    mockLoader(SIGNING_KEY);
+    const fixedNow = new Date("2026-07-28T12:00:00.000Z");
+    const result = await getSignedManifest(fixedNow);
+
+    expect(result.manifest.signedAt).toBe("2026-07-28T12:00:00.000Z");
+  });
+
+  it("produces a signature that passes verifyManifestSignature", async () => {
+    mockLoader(SIGNING_KEY);
+    const result = await getSignedManifest();
+
+    expect(verifyManifestSignature(result, SIGNING_KEY)).toBe(true);
+  });
+
+  it("two calls at different times produce different signatures", async () => {
+    mockLoader(SIGNING_KEY);
+    const r1 = await getSignedManifest(new Date("2026-07-28T10:00:00.000Z"));
+    const r2 = await getSignedManifest(new Date("2026-07-28T11:00:00.000Z"));
+
+    expect(r1.signature).not.toBe(r2.signature);
+  });
+
+  it("falls back to env var when secret loader throws", async () => {
+    mockLoaderThrows();
+    const oldEnv = process.env["WEBHOOK_EGRESS_SIGNING_KEY"];
+    process.env["WEBHOOK_EGRESS_SIGNING_KEY"] = "env-fallback-key-for-testing";
+
+    try {
+      const result = await getSignedManifest();
+      expect(result.manifest.version).toBe(MANIFEST_VERSION);
+      expect(result.signature).toBeTruthy();
+    } finally {
+      if (oldEnv === undefined) {
+        delete process.env["WEBHOOK_EGRESS_SIGNING_KEY"];
+      } else {
+        process.env["WEBHOOK_EGRESS_SIGNING_KEY"] = oldEnv;
+      }
+    }
+  });
+
+  it("uses insecure fallback key when neither loader nor env has the key", async () => {
+    mockLoaderThrows();
+    const oldEnv = process.env["WEBHOOK_EGRESS_SIGNING_KEY"];
+    delete process.env["WEBHOOK_EGRESS_SIGNING_KEY"];
+
+    try {
+      const result = await getSignedManifest();
+      expect(result.manifest.version).toBe(MANIFEST_VERSION);
+    } finally {
+      if (oldEnv !== undefined) {
+        process.env["WEBHOOK_EGRESS_SIGNING_KEY"] = oldEnv;
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /.well-known/webhook-egress-ips – HTTP layer
+// ---------------------------------------------------------------------------
+
+import request from "supertest";
+import express from "express";
+import { webhookEgressIpsRouter } from "../../../../src/routes/webhookEgressIps.js";
+
+describe("GET /.well-known/webhook-egress-ips", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockLoader(SIGNING_KEY);
+  });
+
+  it("responds 200 with JSON body containing manifest, signature, and algorithm", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+    expect(res.body).toMatchObject({
+      algorithm: "hmac-sha256",
+      signature: expect.stringMatching(/^[0-9a-f]{64}$/),
+      manifest: {
+        version: expect.any(Number),
+        ips: expect.any(Array),
+        signedAt: expect.any(String),
+      },
+    });
+  });
+
+  it("sets Cache-Control public max-age header", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    expect(res.headers["cache-control"]).toContain("public");
+    expect(res.headers["cache-control"]).toContain(
+      `max-age=${MANIFEST_CACHE_TTL_SECONDS}`
+    );
+  });
+
+  it("returns a signature that verifies with the signing key", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    expect(verifyManifestSignature(res.body, SIGNING_KEY)).toBe(true);
+  });
+
+  it("includes ips from the canonical list in the manifest body", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    const sorted = [...WEBHOOK_EGRESS_IPS].sort();
+    expect(res.body.manifest.ips).toEqual(sorted);
+  });
+
+  it("manifest version matches MANIFEST_VERSION constant", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    expect(res.body.manifest.version).toBe(MANIFEST_VERSION);
+  });
+
+  it("signedAt is a valid ISO-8601 timestamp", async () => {
+    const app = express();
+    app.use(webhookEgressIpsRouter);
+    const res = await request(app).get("/.well-known/webhook-egress-ips");
+
+    expect(new Date(res.body.manifest.signedAt).toISOString()).toBe(
+      res.body.manifest.signedAt
+    );
+  });
+});


### PR DESCRIPTION
Issue #534 – Webhook egress IP allow-list:
- Add src/services/webhooks/egressIpAllowList.ts with HMAC-SHA256 signed manifest (WEBHOOK_EGRESS_SIGNING_KEY via secret loader)
- Add GET /.well-known/webhook-egress-ips route with Cache-Control public, max-age=3600 header
- Mount route in src/app.ts
- 32 unit/HTTP tests covering canonicalisation, signature accept/reject, key fallback, and full HTTP contract

Issue #580 – Audit-log signed export job:
- Add src/jobs/auditSignedExport.ts with gzip-compressed tarball (tar-stream + zlib) containing audit-logs.json + manifest.json
- Manifest signed with detached PGP signature (openpgp library) using AUDIT_EXPORT_PGP_PRIVATE_KEY sourced from secret loader
- Key fetched fresh per run for safe key rotation during export
- Follows runInstrumentedJob pattern for Pushgateway metrics
- 39 tests covering NDJSON serialisation, SHA-256, tarball validity, PGP sign/verify, full export flow, and job runner integration

Dependencies: openpgp, tar-stream, @types/tar-stream
closes #534 
closes #580 