### PR TITLE
feat: publish SPDX SBOM sidecar

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -53,11 +53,29 @@ jobs:
         run: |
           echo "hashes=$(sha256sum "${ARTIFACT_NAME}" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p sbom
+          npx @cyclonedx/cyclonedx-npm --output-format JSON --output-file sbom/cyclonedx-sbom.json
+
+      - name: Generate SPDX SBOM and checksum
+        run: |
+          npx tsx scripts/generate-spdx.ts --input sbom/cyclonedx-sbom.json --output sbom/spdx-sbom.json
+          sha256sum sbom/spdx-sbom.json > sbom/spdx-sbom.json.sha256
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-artifact
           path: ${{ env.ARTIFACT_NAME }}
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-files
+          path: sbom/
           if-no-files-found: error
           retention-days: 5
 
@@ -193,6 +211,12 @@ jobs:
         with:
           name: cosign-bundle
 
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom-files
+          path: sbom/
+
       - name: Upload assets to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -205,4 +229,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber \
             "${ARTIFACT_NAME}" \
-            "${ARTIFACT_NAME}.cosign.bundle"
+            "${ARTIFACT_NAME}.cosign.bundle" \
+            sbom/cyclonedx-sbom.json \
+            sbom/spdx-sbom.json \
+            sbom/spdx-sbom.json.sha256

--- a/scripts/generate-spdx.ts
+++ b/scripts/generate-spdx.ts
@@ -1,0 +1,236 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface CycloneDxComponent {
+  type?: string;
+  name: string;
+  version?: string;
+  "bom-ref"?: string;
+  purl?: string;
+  hashes?: { alg: string; value: string }[];
+  licenses?: { license?: { id?: string; name?: string } }[];
+  supplier?: { name?: string };
+  description?: string;
+}
+
+interface CycloneDxMetadata {
+  component?: CycloneDxComponent;
+  timestamp?: string;
+}
+
+interface CycloneDxBom {
+  bomFormat: string;
+  specVersion: string;
+  version: number;
+  metadata?: CycloneDxMetadata;
+  components?: CycloneDxComponent[];
+}
+
+interface SpdxCreationInfo {
+  created: string;
+  creators: string[];
+  licenseListVersion?: string;
+}
+
+interface SpdxChecksum {
+  algorithm: string;
+  value: string;
+}
+
+interface SpdxExternalRef {
+  referenceCategory: string;
+  referenceType: string;
+  referenceLocator: string;
+}
+
+interface SpdxPackage {
+  SPDXID: string;
+  name: string;
+  versionInfo: string;
+  filesAnalyzed: boolean;
+  licenseConcluded: string;
+  licenseDeclared: string;
+  downloadLocation: string;
+  checksums?: SpdxChecksum[];
+  externalRefs?: SpdxExternalRef[];
+  supplier?: string;
+}
+
+interface SpdxRelationship {
+  spdxElementId: string;
+  relatedSpdxElement: string;
+  relationshipType: string;
+}
+
+interface SpdxDocument {
+  spdxVersion: string;
+  dataLicense: string;
+  SPDXID: string;
+  name: string;
+  creationInfo: SpdxCreationInfo;
+  packages: SpdxPackage[];
+  relationships: SpdxRelationship[];
+}
+
+function hashComponentName(name: string, version: string): string {
+  const raw = `${name}@${version}`;
+  return `SPDXRef-${createHash("sha256").update(raw).digest("hex").slice(0, 12)}`;
+}
+
+function toSpdxChecksum(hashes: { alg: string; value: string }[]): SpdxChecksum[] {
+  const algMap: Record<string, string> = {
+    "SHA-1": "SHA1",
+    "SHA-256": "SHA256",
+    "SHA-384": "SHA384",
+    "SHA-512": "SHA512",
+    "MD5": "MD5",
+  };
+  return hashes
+    .filter((h) => algMap[h.alg])
+    .map((h) => ({ algorithm: algMap[h.alg], value: h.value }));
+}
+
+function extractLicense(licenses?: { license?: { id?: string; name?: string } }[]): string {
+  if (!licenses || licenses.length === 0) return "NOASSERTION";
+  const ids = licenses
+    .map((l) => l.license?.id || l.license?.name)
+    .filter(Boolean);
+  if (ids.length === 0) return "NOASSERTION";
+  if (ids.length === 1) return ids[0]!;
+  return `(${ids.join(" AND ")})`;
+}
+
+function toSpdxId(value: string): string {
+  return `SPDXRef-${value.replace(/[^a-zA-Z0-9.-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "")}`;
+}
+
+export function convertCyclonedxToSpdx(cdxJson: string): string {
+  const bom: CycloneDxBom = JSON.parse(cdxJson);
+
+  const rootComponent = bom.metadata?.component;
+  const components = bom.components ?? [];
+  const rootName = rootComponent?.name ?? "unknown";
+  const rootVersion = rootComponent?.version ?? "0.0.0";
+  const documentName = `${rootName} ${rootVersion}`;
+  const now = new Date().toISOString().replace(/\.\d+Z$/, "Z");
+
+  const packages: SpdxPackage[] = [];
+  const relationships: SpdxRelationship[] = [];
+
+  const rootSpdxId = toSpdxId(rootName);
+  packages.push({
+    SPDXID: rootSpdxId,
+    name: rootName,
+    versionInfo: rootVersion,
+    filesAnalyzed: false,
+    licenseConcluded: rootComponent ? extractLicense(rootComponent.licenses) : "NOASSERTION",
+    licenseDeclared: rootComponent ? extractLicense(rootComponent.licenses) : "NOASSERTION",
+    downloadLocation: "NOASSERTION",
+  });
+
+  for (const comp of components) {
+    const name = comp.name;
+    const version = comp.version ?? "0.0.0";
+    const spdxId = hashComponentName(name, version);
+
+    packages.push({
+      SPDXID: spdxId,
+      name,
+      versionInfo: version,
+      filesAnalyzed: false,
+      licenseConcluded: extractLicense(comp.licenses),
+      licenseDeclared: extractLicense(comp.licenses),
+      downloadLocation: "NOASSERTION",
+      checksums: comp.hashes ? toSpdxChecksum(comp.hashes) : undefined,
+      externalRefs: comp.purl
+        ? [{ referenceCategory: "PACKAGE-MANAGER", referenceType: "purl", referenceLocator: comp.purl }]
+        : undefined,
+      supplier: comp.supplier?.name,
+    });
+
+    relationships.push({
+      spdxElementId: rootSpdxId,
+      relatedSpdxElement: spdxId,
+      relationshipType: "DEPENDS_ON",
+    });
+  }
+
+  relationships.unshift({
+    spdxElementId: "SPDXRef-DOCUMENT",
+    relatedSpdxElement: rootSpdxId,
+    relationshipType: "DESCRIBES",
+  });
+
+  const document: SpdxDocument = {
+    spdxVersion: "SPDX-2.3",
+    dataLicense: "CC0-1.0",
+    SPDXID: "SPDXRef-DOCUMENT",
+    name: documentName,
+    creationInfo: {
+      created: now,
+      creators: ["Tool: veritasor-generate-spdx"],
+    },
+    packages,
+    relationships,
+  };
+
+  return JSON.stringify(document, null, 2);
+}
+
+export function computeSha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+interface CliArgs {
+  input?: string;
+  output?: string;
+}
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--input":
+        args.input = argv[++i];
+        break;
+      case "--output":
+        args.output = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  return args;
+}
+
+async function runGenerateSpdxCli(argv: string[]): Promise<void> {
+  const args = parseCliArgs(argv);
+  let input: string;
+  if (args.input) {
+    input = await readFile(resolve(args.input), "utf8");
+  } else {
+    input = await new Promise<string>((resolveStdin) => {
+      let data = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => { data += chunk; });
+      process.stdin.on("end", () => resolveStdin(data));
+    });
+  }
+
+  const spdxJson = convertCyclonedxToSpdx(input);
+
+  if (args.output) {
+    await writeFile(resolve(args.output), spdxJson, "utf8");
+  } else {
+    process.stdout.write(spdxJson);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runGenerateSpdxCli(process.argv.slice(2)).catch((err) => {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/tests/scripts/generate-spdx.test.ts
+++ b/tests/scripts/generate-spdx.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  convertCyclonedxToSpdx,
+  computeSha256,
+  parseCliArgs,
+} from "../../scripts/generate-spdx";
+
+const MINIMAL_CDX = JSON.stringify({
+  bomFormat: "CycloneDX",
+  specVersion: "1.4",
+  version: 1,
+  metadata: {
+    component: { name: "my-app", version: "1.0.0", licenses: [{ license: { id: "MIT" } }] },
+    timestamp: "2024-01-01T00:00:00Z",
+  },
+  components: [
+    {
+      type: "library",
+      name: "express",
+      version: "4.18.2",
+      purl: "pkg:npm/express@4.18.2",
+      hashes: [{ alg: "SHA-512", value: "abc123" }],
+      licenses: [{ license: { id: "MIT" } }],
+      supplier: { name: "OpenJS Foundation" },
+    },
+    {
+      type: "library",
+      name: "lodash",
+      version: "4.17.21",
+      purl: "pkg:npm/lodash@4.17.21",
+      licenses: [{ license: { id: "MIT" } }],
+    },
+  ],
+});
+
+const CDX_NO_LICENSE = JSON.stringify({
+  bomFormat: "CycloneDX",
+  specVersion: "1.4",
+  version: 1,
+  metadata: { component: { name: "no-license-app", version: "0.1.0" } },
+  components: [],
+});
+
+const CDX_MULTI_LICENSE = JSON.stringify({
+  bomFormat: "CycloneDX",
+  specVersion: "1.4",
+  version: 1,
+  metadata: { component: { name: "multi", version: "1.0" } },
+  components: [
+    {
+      type: "library",
+      name: "dual-licensed-pkg",
+      version: "2.0.0",
+      licenses: [
+        { license: { id: "MIT" } },
+        { license: { id: "Apache-2.0" } },
+      ],
+    },
+  ],
+});
+
+const CDX_NO_COMPONENTS = JSON.stringify({
+  bomFormat: "CycloneDX",
+  specVersion: "1.4",
+  version: 1,
+  metadata: { component: { name: "empty", version: "0.0.0", licenses: [{ license: { id: "MIT" } }] } },
+});
+
+// ─── convertCyclonedxToSpdx ───────────────────────────────────────────────────
+
+describe("convertCyclonedxToSpdx", () => {
+  it("produces valid SPDX JSON with the correct structure", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    expect(result.spdxVersion).toBe("SPDX-2.3");
+    expect(result.dataLicense).toBe("CC0-1.0");
+    expect(result.SPDXID).toBe("SPDXRef-DOCUMENT");
+    expect(result.name).toBe("my-app 1.0.0");
+    expect(result.creationInfo.creators).toEqual(["Tool: veritasor-generate-spdx"]);
+    expect(result.creationInfo.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it("maps the root package correctly", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    const root = result.packages.find((p: { SPDXID: string }) => p.SPDXID === "SPDXRef-my-app");
+    expect(root).toBeDefined();
+    expect(root.name).toBe("my-app");
+    expect(root.versionInfo).toBe("1.0.0");
+    expect(root.filesAnalyzed).toBe(false);
+    expect(root.licenseConcluded).toBe("MIT");
+    expect(root.downloadLocation).toBe("NOASSERTION");
+  });
+
+  it("maps dependency packages with checksums and external refs", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    const express = result.packages.find((p: { name: string }) => p.name === "express");
+    expect(express).toBeDefined();
+    expect(express.versionInfo).toBe("4.18.2");
+    expect(express.checksums).toEqual([{ algorithm: "SHA512", value: "abc123" }]);
+    expect(express.externalRefs).toEqual([
+      { referenceCategory: "PACKAGE-MANAGER", referenceType: "purl", referenceLocator: "pkg:npm/express@4.18.2" },
+    ]);
+    expect(express.supplier).toBe("OpenJS Foundation");
+  });
+
+  it("creates DEPENDS_ON and DESCRIBES relationships", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    const describes = result.relationships.find(
+      (r: { relationshipType: string }) => r.relationshipType === "DESCRIBES"
+    );
+    expect(describes).toBeDefined();
+    expect(describes.spdxElementId).toBe("SPDXRef-DOCUMENT");
+    expect(describes.relatedSpdxElement).toBe("SPDXRef-my-app");
+
+    const dependsOn = result.relationships.filter(
+      (r: { relationshipType: string }) => r.relationshipType === "DEPENDS_ON"
+    );
+    expect(dependsOn.length).toBe(2);
+    expect(dependsOn[0].spdxElementId).toBe("SPDXRef-my-app");
+  });
+
+  it("sets NOASSERTION when no license info is present", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(CDX_NO_LICENSE));
+    const root = result.packages.find((p: { SPDXID: string }) => p.SPDXID === "SPDXRef-no-license-app");
+    expect(root.licenseConcluded).toBe("NOASSERTION");
+    expect(root.licenseDeclared).toBe("NOASSERTION");
+  });
+
+  it("handles AND compound licenses", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(CDX_MULTI_LICENSE));
+    const pkg = result.packages.find((p: { name: string }) => p.name === "dual-licensed-pkg");
+    expect(pkg.licenseConcluded).toBe("(MIT AND Apache-2.0)");
+  });
+
+  it("works with no components array", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(CDX_NO_COMPONENTS));
+    expect(result.packages).toHaveLength(1);
+    expect(result.relationships).toHaveLength(1);
+    expect(result.relationships[0].relationshipType).toBe("DESCRIBES");
+  });
+
+  it("generates unique SPDXIDs for different packages", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    const ids = result.packages.map((p: { SPDXID: string }) => p.SPDXID);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("handles components without hashes gracefully", () => {
+    const result = JSON.parse(convertCyclonedxToSpdx(MINIMAL_CDX));
+    const lodash = result.packages.find((p: { name: string }) => p.name === "lodash");
+    expect(lodash.checksums).toBeUndefined();
+  });
+
+  it("rejects invalid JSON input", () => {
+    expect(() => convertCyclonedxToSpdx("not-json")).toThrow();
+  });
+});
+
+// ─── computeSha256 ────────────────────────────────────────────────────────────
+
+describe("computeSha256", () => {
+  it("computes the well-known digest of an empty string", () => {
+    expect(computeSha256("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(computeSha256("hello")).toBe(computeSha256("hello"));
+  });
+
+  it("produces different hashes for different inputs", () => {
+    expect(computeSha256("a")).not.toBe(computeSha256("b"));
+  });
+});
+
+// ─── parseCliArgs ─────────────────────────────────────────────────────────────
+
+describe("parseCliArgs", () => {
+  it("parses --input and --output", () => {
+    expect(parseCliArgs(["--input", "in.json", "--output", "out.json"])).toEqual({
+      input: "in.json",
+      output: "out.json",
+    });
+  });
+
+  it("returns empty object when no args given", () => {
+    expect(parseCliArgs([])).toEqual({});
+  });
+
+  it("throws on unknown flags", () => {
+    expect(() => parseCliArgs(["--unknown", "x"])).toThrow(/Unknown argument/);
+  });
+});


### PR DESCRIPTION
Closes #566

## Summary

Adds SPDX SBOM sidecar generation alongside the existing CycloneDX SBOM and uploads both to GitHub release assets with a checksum file.

## Changes

### New files
- **`scripts/generate-spdx.ts`** — Converts CycloneDX JSON to SPDX 2.3 JSON. Reads CycloneDX via `--input` (or stdin), maps components to SPDX packages with checksums, purl external refs, and license info. Exports `convertCyclonedxToSpdx()` for testability. SHA-256 computation exported as `computeSha256()`. Includes CLI entrypoint guard.
- **`tests/scripts/generate-spdx.test.ts`** — 16 tests covering: valid SPDX document structure, root package mapping, dependency mapping with checksums/external refs, DESCRIBES/DEPENDS_ON relationships, NOASSERTION for missing licenses, AND compound licenses, empty components, unique SPDXIDs, components without hashes, invalid JSON rejection, `computeSha256` determinism, CLI arg parsing, and unknown flag rejection.

### Modified files
- **`.github/workflows/slsa-provenance.yml`** — Added two steps to the `build` job: (1) Generate CycloneDX JSON SBOM via `@cyclonedx/cyclonedx-npm`, (2) Convert to SPDX and compute SHA-256 checksum. Uploads `sbom/` directory as artifact. In the `release` job, downloads SBOM artifacts and uploads `sbom/cyclonedx-sbom.json`, `sbom/spdx-sbom.json`, and `sbom/spdx-sbom.json.sha256` to the GitHub release.

## Verification

- `npm test` — all existing and new tests pass
- New test file: 16 tests, all passing
- Existing script tests (verify-provenance): 42 tests, all passing
- The `@cyclonedx/cyclonedx-npm` tool is already a devDependency and used in the security-audit workflow