### PR TITLE
feat: export PgBouncer pool metrics to Prometheus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,15 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/veritasor
 # Prometheus metrics are exposed at /metrics when enabled.
 # METRICS_ENABLED=true
 
+# Optional PgBouncer admin-console exporter. Keep this credential separate from
+# DATABASE_URL and grant its user only PgBouncer stats access (stats_users).
+# The URL must target the PgBouncer admin database, normally /pgbouncer.
+# PGBOUNCER_METRICS_ADMIN_URL=postgresql://metrics_user:secret@pgbouncer:6432/pgbouncer
+# Scrapes are completion-scheduled with one connection; values are clamped to
+# 1s..5m for the interval and 100ms..min(interval,30s) for the query timeout.
+# PGBOUNCER_METRICS_SCRAPE_INTERVAL_MS=15000
+# PGBOUNCER_METRICS_QUERY_TIMEOUT_MS=2000
+
 # Pushgateway URL for batch job metrics (src/jobs/). Batch jobs are
 # short-lived and can exit before Prometheus's next scrape, so they push
 # their metrics here at completion instead. Leave unset to disable (jobs

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -13,3 +13,34 @@ Batch-flush deadlines and queue waits are traced with dedicated OpenTelemetry sp
 - `queue.size`: The size of the batching queue when the item was enqueued.
 - `queue.wait_time_ms`: The duration (in ms) the item waited in the queue before processing.
 - `batch.size`: The number of items processed during a batch flush.
+
+## PgBouncer pool metrics
+
+Set `METRICS_ENABLED=true` and provide `PGBOUNCER_METRICS_ADMIN_URL` to add
+PgBouncer runtime statistics to the existing `/metrics` registry. The exporter
+runs in-process but uses an isolated pool limited to one connection. It runs
+`SHOW POOLS` and `SHOW STATS` after the prior cycle finishes, so a slow or failed
+admin query cannot create overlapping work.
+
+Use a dedicated PgBouncer account listed in `stats_users`; do not reuse the
+application database credential or put an admin credential in `DATABASE_URL`.
+The URL must target PgBouncer's virtual admin database (normally `pgbouncer`).
+Store the URL in the deployment secret manager and never log it. `admin_users`
+is not required: the exporter executes only read-only `SHOW` commands.
+
+Configuration:
+
+- `PGBOUNCER_METRICS_ADMIN_URL`: explicit admin-console connection URL. Unset disables the exporter.
+- `PGBOUNCER_METRICS_SCRAPE_INTERVAL_MS`: default 15000, clamped to 1000..300000.
+- `PGBOUNCER_METRICS_QUERY_TIMEOUT_MS`: default 2000, clamped to 100..min(interval, 30000).
+
+Pool gauges carry `database` and `user`; server connection gauges also carry the
+bounded `state` label. `SHOW STATS` totals are gauges because PgBouncer can reset
+them on restart or `RELOAD`. Exporter health is reported by
+`pgbouncer_scraper_enabled`, `pgbouncer_scrape_success`, `pgbouncer_scrape_errors_total`, scrape duration, and
+the last-success timestamp. A failed scrape preserves the last good pool series
+and does not affect application database traffic.
+
+Prometheus recording and alerting rules live in `ops/alerts/backend.rules.yaml`.
+They aggregate pool-user series at database scope for queue alerts and alert when
+admin authentication or connectivity remains broken.

--- a/docs/runbooks/capacity-alerts.md
+++ b/docs/runbooks/capacity-alerts.md
@@ -2,7 +2,7 @@
 
 ## WebhookDlqDepthWarning / WebhookDlqDepthCritical
 
-**Metric:** `webhook_dlq_depth{provider}`  
+**Metric:** `webhook_dlq_depth{provider}`
 **Thresholds:** warning > 50 for 5 m · critical > 200 for 2 m
 
 **What it means.** The `webhook_dead_letters` table is accumulating rows that
@@ -26,7 +26,7 @@ the consumer has not retried successfully.
 
 ## PgPoolHighUtilization / PgPoolSaturated
 
-**Metric:** `pg_pool_active_connections / pg_pool_max_connections`  
+**Metric:** `pg_pool_active_connections / pg_pool_max_connections`
 **Thresholds:** warning > 80 % for 3 m · critical > 95 % for 1 m
 
 **What it means.** The pg connection pool is near or at capacity. New requests
@@ -49,7 +49,7 @@ will block on `connectionTimeoutMillis` (default 2 s) then fail with 503.
 
 ## SorobanSubmitLagHigh / SorobanSubmitLagCritical / SorobanRetryBudgetExhausted
 
-**Metrics:** `soroban_submit_lag_seconds` (histogram) · `soroban_retry_budget_exhausted_total`  
+**Metrics:** `soroban_submit_lag_seconds` (histogram) · `soroban_retry_budget_exhausted_total`
 **SLO:** p95 on-chain confirmation < 60 s (warning) / < 180 s (critical)
 
 **What it means.** Attestations are taking longer than expected to confirm on
@@ -87,9 +87,9 @@ are being silently dropped.
 
 ---
 
-## PgBouncerQueueDepthWarning / PgBouncerQueueDepthCritical / PgBouncerAvgWaitTimeHigh
+## PgBouncerQueueDepthWarning / PgBouncerQueueDepthCritical / PgBouncerMaxWaitTimeHigh
 
-**Metrics:** `pgbouncer_waiting_clients` (gauge) · `pgbouncer_avg_wait_time_seconds` (gauge)  
+**Metrics:** `pgbouncer_waiting_clients` (gauge) · `pgbouncer_max_wait_seconds` (gauge)
 **Thresholds:** warning > 10 waiting for 30 s · critical > 50 waiting for 15 s · avg wait > 0.5 s for 30 s
 
 **What it means.** Clients are queuing for server connections in PgBouncer.
@@ -129,6 +129,16 @@ application-level symptoms appear.
    `max_client_conn` headroom. Monitor `pgbouncer_server_connections`
    gauge — if it hits `max_db_connections`, the pool is at hard capacity.
 
-6. For `PgBouncerAvgWaitTimeHigh`: average wait > 500 ms means clients
+6. For `PgBouncerMaxWaitTimeHigh`: average wait > 500 ms means clients
    spend significant time queued. Check `pgbouncer_avg_query_time_seconds`
    — if queries are slow, fix the query or add read replicas.
+
+## PgBouncer metrics scrape failure
+
+Check `pgbouncer_scrape_errors_total` by reason. For `authentication`, verify the
+dedicated exporter user is in PgBouncer `stats_users` and rotate its secret if
+needed. For `connection` or `timeout`, verify the application pod can reach the
+PgBouncer admin port and that the configured timeout is below the scrape
+interval. Never substitute the normal application database credential. The
+application continues serving traffic and retains the last good pool samples
+while the exporter is degraded.

--- a/ops/alerts/backend.rules.yaml
+++ b/ops/alerts/backend.rules.yaml
@@ -157,8 +157,20 @@ groups:
             This is above our 200ms SLO.
           runbook: "https://github.com/veritasor/backend/blob/main/docs/runbooks/capacity-alerts.md#attestationsubmitlatencyhigh"
 
+      - record: pgbouncer:waiting_clients:sum
+        expr: sum by (database) (pgbouncer_waiting_clients)
+
+      - record: pgbouncer:active_clients:sum
+        expr: sum by (database) (pgbouncer_active_clients)
+
+      - record: pgbouncer:server_connections:sum
+        expr: sum by (database, state) (pgbouncer_server_connections)
+
+      - record: pgbouncer:scrape_age_seconds
+        expr: time() - pgbouncer_last_successful_scrape_timestamp_seconds
+
       - alert: PgBouncerQueueDepthWarning
-        expr: pgbouncer_waiting_clients > 10
+        expr: pgbouncer:waiting_clients:sum > 10
         for: 30s
         labels:
           severity: warning
@@ -172,7 +184,7 @@ groups:
           runbook: "https://github.com/veritasor/backend/blob/main/docs/runbooks/capacity-alerts.md#pgbouncerqueuedepthwarning--pgbouncerqueuedepthcritical"
 
       - alert: PgBouncerQueueDepthCritical
-        expr: pgbouncer_waiting_clients > 50
+        expr: pgbouncer:waiting_clients:sum > 50
         for: 15s
         labels:
           severity: critical
@@ -185,19 +197,30 @@ groups:
             Immediate action required: scale PgBouncer or investigate query latency.
           runbook: "https://github.com/veritasor/backend/blob/main/docs/runbooks/capacity-alerts.md#pgbouncerqueuedepthwarning--pgbouncerqueuedepthcritical"
 
-      - alert: PgBouncerAvgWaitTimeHigh
-        expr: pgbouncer_avg_wait_time_seconds > 0.5
+      - alert: PgBouncerMaxWaitTimeHigh
+        expr: max by (database) (pgbouncer_max_wait_seconds) > 0.5
         for: 30s
         labels:
           severity: warning
           team: backend
         annotations:
-          summary: "PgBouncer average wait time elevated ({{ $labels.database }})"
+          summary: "PgBouncer oldest client wait elevated ({{ $labels.database }})"
           description: >
-            Average wait time for a server connection is {{ $value | humanizeDuration }}
+            The oldest client has waited {{ $value | humanizeDuration }} for a server connection
             in PgBouncer database {{ $labels.database }}. This indicates pool saturation.
           runbook: "https://github.com/veritasor/backend/blob/main/docs/runbooks/capacity-alerts.md#pgbouncerqueuedepthwarning--pgbouncerqueuedepthcritical"
 
+
+      - alert: PgBouncerMetricsScrapeFailed
+        expr: pgbouncer_scrape_success == 0 and on() pgbouncer_scraper_enabled == 1
+        for: 2m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: "PgBouncer metrics scraper is failing"
+          description: "The application cannot read the PgBouncer admin console. Check network access and the least-privilege admin credential."
+          runbook: "https://github.com/veritasor/backend/blob/main/docs/runbooks/capacity-alerts.md#pgbouncer-metrics-scrape-failure"
       # ── mTLS ─────────────────────────────────────────────────────────────────
       - alert: MtlsHandshakeFailuresSpike
         expr: >

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,44 +46,11 @@ import {
   stopIdempotencySweeper,
 } from "./middleware/idempotency.js";
 import {
-  startPgBouncerScraper,
-  stopPgBouncerScraper,
   startPgBouncerScraperIfNeeded,
-  stopPgBouncerScraperIfNeeded,
 } from "./services/pgbouncerScraper.js";
-
-/**
- * Handle to the running PgBouncer scraper timer.
- * Stored at module scope so the production boot path and tests can share
- * a single instance, and so `stopPgBouncerScraper()` is idempotent.
- */
-let pgbouncerScraperTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Active SPIFFE SVID provider when mTLS uses the Workload API. */
 let activeSvidProvider: SvidProvider | undefined;
-
-/**
- * Start the PgBouncer stats scraper.
- *
- * No-op in test environments so unit tests can drive the scraper manually
- * without racing a real interval.
- */
-export async function startPgBouncerScraperIfNeeded(): Promise<void> {
-  if (process.env.NODE_ENV === 'test') return;
-  if (pgbouncerScraperTimer) return;
-  await startPgBouncerScraper();
-  pgbouncerScraperTimer = setTimeout(() => {}, 0); // placeholder to track started state
-}
-
-/**
- * Stop the PgBouncer stats scraper, if one was started.
- * Safe to call multiple times.
- */
-export async function stopPgBouncerScraperIfNeeded(): Promise<void> {
-  if (!pgbouncerScraperTimer && process.env.NODE_ENV !== 'test') return;
-  await stopPgBouncerScraper();
-  pgbouncerScraperTimer = null;
-}
 
 export function stopSpiffeSvidProviderIfNeeded(): void {
   activeSvidProvider?.stop();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,6 +22,14 @@ export const envSchema = z.object({
   PG_CONN_TIMEOUT_MS: z.string().optional(),
   PGSSL: z.string().optional(),
   PGSSL_REJECT_UNAUTHORIZED: z.string().optional(),
+  PGBOUNCER_METRICS_ADMIN_URL: z.string().url(
+    "PGBOUNCER_METRICS_ADMIN_URL must be a valid URL",
+  ).refine(
+    (value) => value.startsWith("postgres://") || value.startsWith("postgresql://"),
+    "PGBOUNCER_METRICS_ADMIN_URL must use postgres or postgresql",
+  ).optional(),
+  PGBOUNCER_METRICS_SCRAPE_INTERVAL_MS: z.string().optional(),
+  PGBOUNCER_METRICS_QUERY_TIMEOUT_MS: z.string().optional(),
   STELLAR_NETWORK: z.enum(["testnet", "public", "futurenet"]).default("testnet"),
   SOROBAN_RPC_URL: z.string().url().default("https://soroban-testnet.stellar.org"),
   SOROBAN_CONTRACT_ID: z.string().default(""),
@@ -308,6 +316,19 @@ export const config = {
             ),
         }
       : undefined,
+  },
+  pgbouncerMetrics: {
+    adminUrl: parsedEnv.PGBOUNCER_METRICS_ADMIN_URL,
+    scrapeIntervalMs: parsePositiveIntEnv(
+      "PGBOUNCER_METRICS_SCRAPE_INTERVAL_MS",
+      parsedEnv.PGBOUNCER_METRICS_SCRAPE_INTERVAL_MS,
+      15_000,
+    ),
+    queryTimeoutMs: parsePositiveIntEnv(
+      "PGBOUNCER_METRICS_QUERY_TIMEOUT_MS",
+      parsedEnv.PGBOUNCER_METRICS_QUERY_TIMEOUT_MS,
+      2_000,
+    ),
   },
   stellar: {
     network: parsedEnv.STELLAR_NETWORK,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@
  */
 
 import 'dotenv/config';
-import { startServer, stopIdempotencySweeper, stopPgBouncerScraperIfNeeded } from './app.js';
+import { startServer, stopIdempotencySweeper } from './app.js';
+import { stopPgBouncerScraperIfNeeded } from './services/pgbouncerScraper.js';
 import { pool } from './db/client.js';
 import { logger } from './utils/logger.js';
 import { secretLoader } from './utils/secret-loader.js';

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -108,78 +108,88 @@ export const idempotencySweepRunsTotal = new Counter({
 });
 
 /**
- * PgBouncer queue depth and latency metrics.
- *
- * Scraped from `SHOW STATS` on the PgBouncer admin database at second granularity.
- * Key metrics exposed:
- *
- * - `pgbouncer_waiting_clients` (gauge, labels: database): clients waiting for a server connection.
- *   Spikes here precede tail-latency incidents.
- * - `pgbouncer_avg_wait_time_seconds` (gauge, labels: database): average wait time in seconds.
- *   Spikes indicate pool saturation.
- * - `pgbouncer_active_clients` (gauge, labels: database): currently active client connections.
- * - `pgbouncer_idle_clients` (gauge, labels: database): idle client connections.
- * - `pgbouncer_server_connections` (gauge, labels: database): active server connections.
- * - `pgbouncer_avg_query_time_seconds` (gauge, labels: database): average query execution time.
- * - `pgbouncer_total_requests_total` (counter, labels: database): total client requests.
- * - `pgbouncer_total_query_time_seconds_total` (counter, labels: database): cumulative query time.
+ * PgBouncer admin-console metrics. Pool series use the bounded
+ * (database,user) key returned by SHOW POOLS; stats use database only.
  */
 export const pgbouncerWaitingClients = new Gauge({
   name: "pgbouncer_waiting_clients",
-  help: "Number of clients waiting for a server connection in PgBouncer pool",
-  labelNames: ["database"] as const,
+  help: "Clients waiting for a server connection in a PgBouncer pool",
+  labelNames: ["database", "user"] as const,
   registers: [metricsRegistry],
 });
 
-export const pgbouncerAvgWaitTimeSeconds = new Gauge({
-  name: "pgbouncer_avg_wait_time_seconds",
-  help: "Average wait time for a server connection in seconds",
-  labelNames: ["database"] as const,
+export const pgbouncerMaxWaitSeconds = new Gauge({
+  name: "pgbouncer_max_wait_seconds",
+  help: "Age in seconds of the oldest waiting client in a PgBouncer pool",
+  labelNames: ["database", "user"] as const,
   registers: [metricsRegistry],
 });
 
 export const pgbouncerActiveClients = new Gauge({
   name: "pgbouncer_active_clients",
-  help: "Number of active client connections in PgBouncer",
-  labelNames: ["database"] as const,
-  registers: [metricsRegistry],
-});
-
-export const pgbouncerIdleClients = new Gauge({
-  name: "pgbouncer_idle_clients",
-  help: "Number of idle client connections in PgBouncer",
-  labelNames: ["database"] as const,
+  help: "Active client connections in a PgBouncer pool",
+  labelNames: ["database", "user"] as const,
   registers: [metricsRegistry],
 });
 
 export const pgbouncerServerConnections = new Gauge({
   name: "pgbouncer_server_connections",
-  help: "Number of active server connections in PgBouncer",
-  labelNames: ["database"] as const,
+  help: "Server connections in a PgBouncer pool by state",
+  labelNames: ["database", "user", "state"] as const,
   registers: [metricsRegistry],
 });
 
 export const pgbouncerAvgQueryTimeSeconds = new Gauge({
   name: "pgbouncer_avg_query_time_seconds",
-  help: "Average query execution time in seconds",
+  help: "Average PgBouncer query execution time in seconds",
   labelNames: ["database"] as const,
   registers: [metricsRegistry],
 });
 
-export const pgbouncerTotalRequestsTotal = new Counter({
-  name: "pgbouncer_total_requests_total",
-  help: "Total number of client requests processed by PgBouncer",
+export const pgbouncerTotalRequests = new Gauge({
+  name: "pgbouncer_total_requests",
+  help: "Current PgBouncer cumulative request count (may reset on restart or RELOAD)",
   labelNames: ["database"] as const,
   registers: [metricsRegistry],
 });
 
-export const pgbouncerTotalQueryTimeSecondsTotal = new Counter({
-  name: "pgbouncer_total_query_time_seconds_total",
-  help: "Cumulative query execution time in seconds",
+export const pgbouncerTotalQueryTimeSeconds = new Gauge({
+  name: "pgbouncer_total_query_time_seconds",
+  help: "Current PgBouncer cumulative query time in seconds (may reset on restart or RELOAD)",
   labelNames: ["database"] as const,
   registers: [metricsRegistry],
 });
 
+export const pgbouncerScraperEnabled = new Gauge({
+  name: "pgbouncer_scraper_enabled",
+  help: "Whether the PgBouncer admin scraper is configured and running (1 or 0)",
+  registers: [metricsRegistry],
+});
+
+export const pgbouncerScrapeSuccess = new Gauge({
+  name: "pgbouncer_scrape_success",
+  help: "Whether the most recent PgBouncer admin scrape succeeded (1 or 0)",
+  registers: [metricsRegistry],
+});
+
+export const pgbouncerScrapeDurationSeconds = new Gauge({
+  name: "pgbouncer_scrape_duration_seconds",
+  help: "Duration of the most recent PgBouncer admin scrape in seconds",
+  registers: [metricsRegistry],
+});
+
+export const pgbouncerLastSuccessfulScrapeTimestampSeconds = new Gauge({
+  name: "pgbouncer_last_successful_scrape_timestamp_seconds",
+  help: "Unix timestamp of the most recent successful PgBouncer admin scrape",
+  registers: [metricsRegistry],
+});
+
+export const pgbouncerScrapeErrorsTotal = new Counter({
+  name: "pgbouncer_scrape_errors_total",
+  help: "Total failed PgBouncer admin scrapes",
+  labelNames: ["reason"] as const,
+  registers: [metricsRegistry],
+});
 /**
  * Adaptive batch-size tuning metrics for Soroban submissions.
  *

--- a/src/services/pgbouncerScraper.ts
+++ b/src/services/pgbouncerScraper.ts
@@ -1,165 +1,211 @@
 /**
- * PgBouncer stats scraper for real-time queue depth monitoring.
+ * Low-overhead PgBouncer admin-console scraper.
  *
- * Scrapes `SHOW STATS` from the PgBouncer admin database at second granularity
- * and exports metrics to Prometheus for alerting on queue depth spikes.
- *
- * Key metrics exposed:
- * - pgbouncer_waiting_clients (gauge): clients waiting for a server connection
- * - pgbouncer_avg_wait_time_seconds (gauge): average wait time in seconds
- * - pgbouncer_active_clients (gauge): active client connections
- * - pgbouncer_idle_clients (gauge): idle client connections
- * - pgbouncer_server_connections (gauge): active server connections
- * - pgbouncer_avg_query_time_seconds (gauge): average query execution time
- * - pgbouncer_total_requests_total (counter): total client requests
- * - pgbouncer_total_query_time_seconds_total (counter): cumulative query time
- *
- * Self-throttling: if scraping takes longer than the interval, skips the next
- * cycle to prevent overlapping scrapes under load.
+ * The admin URL is deliberately independent from DATABASE_URL: an application
+ * database credential must never be promoted to a PgBouncer admin credential.
+ * One connection and a completion-based timer prevent overlap under load.
  */
-
 import pg from "pg";
 import { config } from "../config/index.js";
 import { logger } from "../utils/logger.js";
 import {
-  pgbouncerWaitingClients,
-  pgbouncerAvgWaitTimeSeconds,
   pgbouncerActiveClients,
-  pgbouncerIdleClients,
-  pgbouncerServerConnections,
   pgbouncerAvgQueryTimeSeconds,
-  pgbouncerTotalRequestsTotal,
-  pgbouncerTotalQueryTimeSecondsTotal,
+  pgbouncerLastSuccessfulScrapeTimestampSeconds,
+  pgbouncerMaxWaitSeconds,
+  pgbouncerScrapeDurationSeconds,
+  pgbouncerScrapeErrorsTotal,
+  pgbouncerScraperEnabled,
+  pgbouncerScrapeSuccess,
+  pgbouncerServerConnections,
+  pgbouncerTotalQueryTimeSeconds,
+  pgbouncerTotalRequests,
+  pgbouncerWaitingClients,
 } from "../metrics.js";
 
-export const SCRAPE_INTERVAL_MS = 1000;
-export const SCRAPE_TIMEOUT_MS = 500;
+export const MIN_SCRAPE_INTERVAL_MS = 1_000;
+export const MAX_SCRAPE_INTERVAL_MS = 300_000;
+export const MIN_QUERY_TIMEOUT_MS = 100;
+export const MAX_QUERY_TIMEOUT_MS = 30_000;
 
-interface PgBouncerStatsRow {
-  database: string;
-  total_requests: number;
-  total_received: number;
-  total_sent: number;
-  total_query_time: number;
-  avg_req: number;
-  avg_recv: number;
-  avg_sent: number;
-  avg_query: number;
-  avg_wait: number;
-  waiting_clients: number;
-  idle_clients: number;
-  active_clients: number;
-  servers: number;
+type AdminValue = string | number | null | undefined;
+type AdminRow = Record<string, AdminValue>;
+
+let pool: pg.Pool | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let started = false;
+let scrapeInProgress = false;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
-let scrapeTimer: ReturnType<typeof setTimeout> | null = null;
-let isScraping = false;
-let pgbouncerPool: pg.Pool | null = null;
+export function getPgBouncerScrapeIntervalMs(): number {
+  return clamp(config.pgbouncerMetrics.scrapeIntervalMs, MIN_SCRAPE_INTERVAL_MS, MAX_SCRAPE_INTERVAL_MS);
+}
 
+export function getPgBouncerQueryTimeoutMs(): number {
+  return clamp(
+    config.pgbouncerMetrics.queryTimeoutMs,
+    MIN_QUERY_TIMEOUT_MS,
+    Math.min(MAX_QUERY_TIMEOUT_MS, getPgBouncerScrapeIntervalMs()),
+  );
+}
+
+/** Return the explicitly configured admin URL without deriving or logging it. */
 export function getPgBouncerAdminUrl(): string | null {
-  const dbUrl = new URL(config.db.url);
-  const adminUrl = new URL(dbUrl.toString());
-  adminUrl.pathname = "/pgbouncer";
-  adminUrl.searchParams.set("statement_cache_size", "0");
-  return adminUrl.toString();
+  const value = config.pgbouncerMetrics.adminUrl?.trim();
+  if (!value) return null;
+  const parsed = new URL(value);
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    throw new Error("PgBouncer admin URL must use postgres or postgresql");
+  }
+  return value;
 }
 
-export async function scrapeOnce(): Promise<void> {
-  if (isScraping) {
-    logger.debug("PgBouncer scrape skipped: previous scrape still running");
-    return;
-  }
-
-  const adminUrl = getPgBouncerAdminUrl();
-  if (!adminUrl) {
-    logger.debug("PgBouncer admin URL not configured, skipping scrape");
-    return;
-  }
-
-  isScraping = true;
-  const startTime = Date.now();
-
-  try {
-    if (!pgbouncerPool) {
-      pgbouncerPool = new pg.Pool({
-        connectionString: adminUrl,
-        max: 1,
-        idleTimeoutMillis: 5000,
-        connectionTimeoutMillis: SCRAPE_TIMEOUT_MS,
-      });
+function numeric(row: AdminRow, ...names: string[]): number {
+  for (const name of names) {
+    const value = row[name];
+    if (value !== null && value !== undefined && value !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed) && parsed >= 0) return parsed;
     }
+  }
+  return 0;
+}
 
-    const client = await pgbouncerPool.connect();
-    try {
-      const result = await Promise.race([
-        client.query<PgBouncerStatsRow>("SHOW STATS"),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("scrape timeout")), SCRAPE_TIMEOUT_MS),
-        ),
-      ]);
+function label(value: AdminValue): string {
+  const result = String(value ?? "unknown").trim();
+  return result || "unknown";
+}
 
-      for (const row of result.rows) {
-        const dbLabel = row.database || "default";
+function classifyError(error: unknown): string {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  if (code === "28P01" || code === "28000") return "authentication";
+  if (code === "ETIMEDOUT" || code === "57014") return "timeout";
+  if (["ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH", "ENOTFOUND"].includes(code)) return "connection";
+  if (code) return "query";
+  return "unknown";
+}
 
-        pgbouncerWaitingClients.set({ database: dbLabel }, row.waiting_clients);
-        pgbouncerAvgWaitTimeSeconds.set({ database: dbLabel }, row.avg_wait / 1_000_000);
-        pgbouncerActiveClients.set({ database: dbLabel }, row.active_clients);
-        pgbouncerIdleClients.set({ database: dbLabel }, row.idle_clients);
-        pgbouncerServerConnections.set({ database: dbLabel }, row.servers);
-        pgbouncerAvgQueryTimeSeconds.set({ database: dbLabel }, row.avg_query / 1_000_000);
-        pgbouncerTotalRequestsTotal.inc({ database: dbLabel }, row.total_requests);
-        pgbouncerTotalQueryTimeSecondsTotal.inc(
-          { database: dbLabel },
-          row.total_query_time / 1_000_000,
-        );
-      }
-    } finally {
-      client.release();
-    }
-  } catch (error) {
-    logger.debug({ err: error }, "PgBouncer scrape failed");
-  } finally {
-    isScraping = false;
-    const elapsed = Date.now() - startTime;
+function getPool(): pg.Pool {
+  if (!pool) {
+    pool = new pg.Pool({
+      connectionString: getPgBouncerAdminUrl()!,
+      max: 1,
+      idleTimeoutMillis: getPgBouncerScrapeIntervalMs(),
+      connectionTimeoutMillis: getPgBouncerQueryTimeoutMs(),
+      query_timeout: getPgBouncerQueryTimeoutMs(),
+    });
+    pool.on("error", (error) => {
+      logger.warn({ event: "pgbouncer_admin_pool_error", code: classifyError(error) });
+    });
+  }
+  return pool;
+}
 
-    if (elapsed >= SCRAPE_INTERVAL_MS) {
-      logger.warn(
-        { elapsedMs: elapsed, intervalMs: SCRAPE_INTERVAL_MS },
-        "PgBouncer scrape exceeded interval, skipping next cycle (self-throttling)",
+function publish(pools: AdminRow[], stats: AdminRow[]): void {
+  pgbouncerWaitingClients.reset();
+  pgbouncerMaxWaitSeconds.reset();
+  pgbouncerActiveClients.reset();
+  pgbouncerServerConnections.reset();
+  pgbouncerAvgQueryTimeSeconds.reset();
+  pgbouncerTotalRequests.reset();
+  pgbouncerTotalQueryTimeSeconds.reset();
+
+  for (const row of pools) {
+    const labels = { database: label(row.database), user: label(row.user) };
+    pgbouncerWaitingClients.set(labels, numeric(row, "cl_waiting"));
+    pgbouncerMaxWaitSeconds.set(
+      labels,
+      numeric(row, "maxwait") + numeric(row, "maxwait_us") / 1_000_000,
+    );
+    pgbouncerActiveClients.set(labels, numeric(row, "cl_active"));
+    for (const state of ["active", "idle", "used", "tested", "login"] as const) {
+      pgbouncerServerConnections.set(
+        { ...labels, state },
+        numeric(row, `sv_${state}`),
       );
-      scheduleNextScrape(SCRAPE_INTERVAL_MS * 2);
-    } else {
-      scheduleNextScrape(Math.max(0, SCRAPE_INTERVAL_MS - elapsed));
     }
   }
+
+  for (const row of stats) {
+    const labels = { database: label(row.database) };
+    pgbouncerAvgQueryTimeSeconds.set(
+      labels,
+      numeric(row, "avg_query_time", "avg_query") / 1_000_000,
+    );
+    pgbouncerTotalRequests.set(
+      labels,
+      numeric(row, "total_query_count", "total_xact_count", "total_requests"),
+    );
+    pgbouncerTotalQueryTimeSeconds.set(
+      labels,
+      numeric(row, "total_query_time") / 1_000_000,
+    );
+  }
 }
 
-function scheduleNextScrape(delayMs: number): void {
-  if (scrapeTimer) {
-    clearTimeout(scrapeTimer);
+/** Perform one scrape. Failures are observable but never crash the application. */
+export async function scrapeOnce(): Promise<boolean> {
+  if (scrapeInProgress || !getPgBouncerAdminUrl()) return false;
+  scrapeInProgress = true;
+  const startedAt = Date.now();
+  try {
+    const adminPool = getPool();
+    const [poolsResult, statsResult] = await Promise.all([
+      adminPool.query("SHOW POOLS"),
+      adminPool.query("SHOW STATS"),
+    ]);
+    publish(poolsResult.rows as AdminRow[], statsResult.rows as AdminRow[]);
+    pgbouncerScrapeSuccess.set(1);
+    pgbouncerLastSuccessfulScrapeTimestampSeconds.set(Date.now() / 1_000);
+    return true;
+  } catch (error) {
+    const reason = classifyError(error);
+    pgbouncerScrapeSuccess.set(0);
+    pgbouncerScrapeErrorsTotal.inc({ reason });
+    logger.warn({ event: "pgbouncer_scrape_failed", reason });
+    return false;
+  } finally {
+    pgbouncerScrapeDurationSeconds.set((Date.now() - startedAt) / 1_000);
+    scrapeInProgress = false;
   }
-  scrapeTimer = setTimeout(scrapeOnce, delayMs);
 }
 
-export function startPgBouncerScraper(): void {
-  const adminUrl = getPgBouncerAdminUrl();
-  if (!adminUrl) {
-    logger.info("PgBouncer admin URL not configured, scraper not started");
-    return;
-  }
-
-  logger.info("Starting PgBouncer stats scraper (1s interval)");
-  scrapeOnce();
+async function runCycle(): Promise<void> {
+  await scrapeOnce();
+  if (started) timer = setTimeout(runCycle, getPgBouncerScrapeIntervalMs());
+  timer?.unref?.();
 }
 
-export function stopPgBouncerScraper(): void {
-  if (scrapeTimer) {
-    clearTimeout(scrapeTimer);
-    scrapeTimer = null;
+export function startPgBouncerScraper(): boolean {
+  if (started || !getPgBouncerAdminUrl()) return false;
+  started = true;
+  pgbouncerScraperEnabled.set(1);
+  logger.info({ intervalMs: getPgBouncerScrapeIntervalMs() }, "Starting PgBouncer metrics scraper");
+  void runCycle();
+  return true;
+}
+
+export async function stopPgBouncerScraper(): Promise<void> {
+  started = false;
+  pgbouncerScraperEnabled.set(0);
+  if (timer) clearTimeout(timer);
+  timer = null;
+  const currentPool = pool;
+  pool = null;
+  if (currentPool) await currentPool.end();
+}
+
+export function startPgBouncerScraperIfNeeded(): void {
+  if (process.env.NODE_ENV !== "test" && process.env.METRICS_ENABLED === "true") {
+    startPgBouncerScraper();
   }
-  if (pgbouncerPool) {
-    pgbouncerPool.end();
-    pgbouncerPool = null;
-  }
-  logger.info("PgBouncer stats scraper stopped");
+}
+
+export async function stopPgBouncerScraperIfNeeded(): Promise<void> {
+  await stopPgBouncerScraper();
 }

--- a/tests/unit/pgbouncerMetrics.test.ts
+++ b/tests/unit/pgbouncerMetrics.test.ts
@@ -1,129 +1,47 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { metricsRegistry } from "../../src/metrics.js";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
-  pgbouncerWaitingClients,
-  pgbouncerAvgWaitTimeSeconds,
+  metricsRegistry,
   pgbouncerActiveClients,
-  pgbouncerIdleClients,
+  pgbouncerScrapeErrorsTotal,
   pgbouncerServerConnections,
-  pgbouncerAvgQueryTimeSeconds,
-  pgbouncerTotalRequestsTotal,
-  pgbouncerTotalQueryTimeSecondsTotal,
+  pgbouncerWaitingClients,
 } from "../../src/metrics.js";
 
-beforeEach(async () => {
-  await metricsRegistry.resetMetrics();
-});
+beforeEach(() => metricsRegistry.resetMetrics());
 
 describe("PgBouncer metrics", () => {
-  it("registers pgbouncer_waiting_clients gauge", async () => {
+  it("registers pool, stats, and exporter-health families", async () => {
     const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_waiting_clients");
+    for (const name of [
+      "pgbouncer_waiting_clients", "pgbouncer_max_wait_seconds",
+      "pgbouncer_active_clients",
+      "pgbouncer_server_connections", "pgbouncer_avg_query_time_seconds",
+      "pgbouncer_total_requests", "pgbouncer_total_query_time_seconds",
+      "pgbouncer_scraper_enabled", "pgbouncer_scrape_success", "pgbouncer_scrape_duration_seconds",
+      "pgbouncer_last_successful_scrape_timestamp_seconds", "pgbouncer_scrape_errors",
+    ]) expect(output).toContain(name);
   });
 
-  it("registers pgbouncer_avg_wait_time_seconds gauge", async () => {
+  it("separates pools by database and user", async () => {
+    pgbouncerWaitingClients.set({ database: "app", user: "one" }, 2);
+    pgbouncerWaitingClients.set({ database: "app", user: "two" }, 4);
     const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_avg_wait_time_seconds");
+    expect(output).toContain('database="app",user="one"} 2');
+    expect(output).toContain('database="app",user="two"} 4');
   });
 
-  it("registers pgbouncer_active_clients gauge", async () => {
+  it("separates server connection states", async () => {
+    pgbouncerServerConnections.set({ database: "app", user: "one", state: "active" }, 2);
+    pgbouncerServerConnections.set({ database: "app", user: "one", state: "idle" }, 5);
+    expect(await metricsRegistry.metrics()).toContain('state="idle"');
+  });
+
+  it("resets gauges without resetting failure counters", async () => {
+    pgbouncerActiveClients.set({ database: "app", user: "one" }, 3);
+    pgbouncerScrapeErrorsTotal.inc({ reason: "timeout" });
+    pgbouncerActiveClients.reset();
     const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_active_clients");
-  });
-
-  it("registers pgbouncer_idle_clients gauge", async () => {
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_idle_clients");
-  });
-
-  it("registers pgbouncer_server_connections gauge", async () => {
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_server_connections");
-  });
-
-  it("registers pgbouncer_avg_query_time_seconds gauge", async () => {
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_avg_query_time_seconds");
-  });
-
-  it("registers pgbouncer_total_requests_total counter", async () => {
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_total_requests_total");
-  });
-
-  it("registers pgbouncer_total_query_time_seconds_total counter", async () => {
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain("pgbouncer_total_query_time_seconds_total");
-  });
-
-  it("records waiting_clients with database label", async () => {
-    pgbouncerWaitingClients.set({ database: "veritasor" }, 5);
-    pgbouncerWaitingClients.set({ database: "analytics" }, 10);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_waiting_clients{database="veritasor"} 5');
-    expect(output).toContain('pgbouncer_waiting_clients{database="analytics"} 10');
-  });
-
-  it("records avg_wait_time_seconds with database label", async () => {
-    pgbouncerAvgWaitTimeSeconds.set({ database: "veritasor" }, 0.1);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_avg_wait_time_seconds{database="veritasor"} 0.1');
-  });
-
-  it("records active_clients with database label", async () => {
-    pgbouncerActiveClients.set({ database: "veritasor" }, 3);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_active_clients{database="veritasor"} 3');
-  });
-
-  it("records idle_clients with database label", async () => {
-    pgbouncerIdleClients.set({ database: "veritasor" }, 8);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_idle_clients{database="veritasor"} 8');
-  });
-
-  it("records server_connections with database label", async () => {
-    pgbouncerServerConnections.set({ database: "veritasor" }, 2);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_server_connections{database="veritasor"} 2');
-  });
-
-  it("records avg_query_time_seconds with database label", async () => {
-    pgbouncerAvgQueryTimeSeconds.set({ database: "veritasor" }, 0.005);
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('pgbouncer_avg_query_time_seconds{database="veritasor"} 0.005');
-  });
-
-  it("increments total_requests_total counter", async () => {
-    pgbouncerTotalRequestsTotal.inc({ database: "veritasor" }, 1000);
-    const metrics = await metricsRegistry.getMetricsAsJSON();
-    const counter = metrics.find((m) => m.name === "pgbouncer_total_requests_total");
-    expect(counter).toBeDefined();
-    const value = (counter!.values as Array<{ labels: Record<string, string>; value: number }>).find(
-      (v) => v.labels.database === "veritasor",
-    );
-    expect(value?.value).toBe(1000);
-  });
-
-  it("increments total_query_time_seconds_total counter", async () => {
-    pgbouncerTotalQueryTimeSecondsTotal.inc({ database: "veritasor" }, 5.5);
-    const metrics = await metricsRegistry.getMetricsAsJSON();
-    const counter = metrics.find((m) => m.name === "pgbouncer_total_query_time_seconds_total");
-    expect(counter).toBeDefined();
-    const value = (counter!.values as Array<{ labels: Record<string, string>; value: number }>).find(
-      (v) => v.labels.database === "veritasor",
-    );
-    expect(value?.value).toBe(5.5);
-  });
-
-  it("tracks separate databases independently", async () => {
-    pgbouncerWaitingClients.set({ database: "veritasor" }, 5);
-    pgbouncerWaitingClients.set({ database: "analytics" }, 10);
-    pgbouncerActiveClients.set({ database: "veritasor" }, 3);
-    pgbouncerActiveClients.set({ database: "analytics" }, 7);
-
-    const output = await metricsRegistry.metrics();
-    expect(output).toContain('database="veritasor"');
-    expect(output).toContain('database="analytics"');
+    expect(output).not.toContain("pgbouncer_active_clients{");
+    expect(output).toContain('pgbouncer_scrape_errors_total{reason="timeout"} 1');
   });
 });

--- a/tests/unit/pgbouncerScraper.test.ts
+++ b/tests/unit/pgbouncerScraper.test.ts
@@ -1,97 +1,180 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { metricsRegistry } from "../../src/metrics.js";
 
-// Set up mocks before importing the module
-const mockQuery = vi.fn();
-const mockConnect = vi.fn().mockResolvedValue({
-  query: mockQuery,
-  release: vi.fn(),
-});
-const mockPool = {
-  connect: mockConnect,
-  end: vi.fn().mockResolvedValue(undefined),
-};
-
-vi.mock("pg", () => ({
-  default: {
-    Pool: vi.fn().mockImplementation(() => mockPool),
-  },
-}));
-
-vi.mock("../../config/index.js", () => ({
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  end: vi.fn(),
+  on: vi.fn(),
   config: {
-    db: {
-      url: "postgresql://user:pass@localhost:5432/veritasor",
+    pgbouncerMetrics: {
+      adminUrl: "postgresql://metrics:secret@localhost:6432/pgbouncer" as string | undefined,
+      scrapeIntervalMs: 15_000,
+      queryTimeoutMs: 2_000,
     },
   },
 }));
 
-vi.mock("../../src/utils/logger.js", () => ({
-  logger: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
+vi.mock("pg", () => ({
+  default: {
+    Pool: vi.fn(function MockPool() { return { query: mocks.query, end: mocks.end, on: mocks.on }; }),
   },
 }));
+vi.mock("../../src/config/index.js", () => ({ config: mocks.config }));
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
 
-// Import after mocks are set up
-const {
-  getPgBouncerAdminUrl,
-  startPgBouncerScraper,
-  stopPgBouncerScraper,
-  SCRAPE_INTERVAL_MS,
-  SCRAPE_TIMEOUT_MS,
-} = await import("../../src/services/pgbouncerScraper.js");
+const scraper = await import("../../src/services/pgbouncerScraper.js");
+
+const poolRows = [{
+  database: "app", user: "app_user", cl_active: "3", cl_waiting: "2",
+  sv_active: "2", sv_idle: "4", sv_used: "1", sv_tested: "0", sv_login: "1",
+  maxwait: "1", maxwait_us: "250000",
+}];
+const statRows = [{
+  database: "app", total_query_count: "42", total_query_time: "5000000", avg_query_time: "2500",
+}];
 
 beforeEach(async () => {
-  vi.useFakeTimers();
-  await metricsRegistry.resetMetrics();
-  mockQuery.mockReset();
-  mockConnect.mockReset();
-  mockPool.connect.mockResolvedValue({
-    query: mockQuery,
-    release: vi.fn(),
-  });
-  mockPool.end.mockResolvedValue(undefined);
-  await stopPgBouncerScraper();
+  await scraper.stopPgBouncerScraper();
+  metricsRegistry.resetMetrics();
+  mocks.query.mockReset();
+  mocks.on.mockClear();
+  mocks.end.mockReset().mockResolvedValue(undefined);
+  mocks.config.pgbouncerMetrics.adminUrl = "postgresql://metrics:secret@localhost:6432/pgbouncer";
+  mocks.config.pgbouncerMetrics.scrapeIntervalMs = 15_000;
+  mocks.config.pgbouncerMetrics.queryTimeoutMs = 2_000;
 });
 
 afterEach(async () => {
+  await scraper.stopPgBouncerScraper();
   vi.useRealTimers();
-  await stopPgBouncerScraper();
 });
 
 describe("PgBouncer scraper", () => {
-  it("exports SCRAPE_INTERVAL_MS as 1000", () => {
-    expect(SCRAPE_INTERVAL_MS).toBe(1000);
+  it("requires a separate explicit admin URL", () => {
+    mocks.config.pgbouncerMetrics.adminUrl = undefined;
+    expect(scraper.getPgBouncerAdminUrl()).toBeNull();
+    expect(scraper.startPgBouncerScraper()).toBe(false);
+    expect(mocks.query).not.toHaveBeenCalled();
   });
 
-  it("exports SCRAPE_TIMEOUT_MS as 500", () => {
-    expect(SCRAPE_TIMEOUT_MS).toBe(500);
+  it("clamps unsafe interval and timeout values", () => {
+    mocks.config.pgbouncerMetrics.scrapeIntervalMs = 1;
+    mocks.config.pgbouncerMetrics.queryTimeoutMs = 99_999;
+    expect(scraper.getPgBouncerScrapeIntervalMs()).toBe(scraper.MIN_SCRAPE_INTERVAL_MS);
+    expect(scraper.getPgBouncerQueryTimeoutMs()).toBe(scraper.MIN_SCRAPE_INTERVAL_MS);
   });
 
-  it("getPgBouncerAdminUrl returns correct admin URL", () => {
-    const url = getPgBouncerAdminUrl();
-    expect(url).toContain("postgres://");
-    expect(url).toContain("/pgbouncer");
-    expect(url).toContain("statement_cache_size=0");
+  it("scrapes SHOW POOLS and SHOW STATS and converts microseconds", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: poolRows })
+      .mockResolvedValueOnce({ rows: statRows });
+
+    await expect(scraper.scrapeOnce()).resolves.toBe(true);
+    expect(mocks.query).toHaveBeenNthCalledWith(1, "SHOW POOLS");
+    expect(mocks.query).toHaveBeenNthCalledWith(2, "SHOW STATS");
+    const output = await metricsRegistry.metrics();
+    expect(output).toContain('pgbouncer_waiting_clients{database="app",user="app_user"} 2');
+    expect(output).toContain('pgbouncer_max_wait_seconds{database="app",user="app_user"} 1.25');
+    expect(output).toContain('pgbouncer_server_connections{database="app",user="app_user",state="idle"} 4');
+    expect(output).toContain('pgbouncer_avg_query_time_seconds{database="app"} 0.0025');
+    expect(output).toContain('pgbouncer_total_requests{database="app"} 42');
+    expect(output).toContain("pgbouncer_scrape_success 1");
   });
 
-  describe("startPgBouncerScraper", () => {
-    it("starts scraper without error", async () => {
-      await startPgBouncerScraper();
-      // If we get here without throwing, the test passes
-    });
+  it("removes series for pools that disappear", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: poolRows }).mockResolvedValueOnce({ rows: statRows });
+    await scraper.scrapeOnce();
+    mocks.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
+    await scraper.scrapeOnce();
+    expect(await metricsRegistry.metrics()).not.toContain('database="app"');
   });
 
-  describe("stopPgBouncerScraper", () => {
-    it("stops scraper without error", async () => {
-      await stopPgBouncerScraper();
-    });
+  it("falls back safely on admin authentication failure without clearing last good data", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: poolRows }).mockResolvedValueOnce({ rows: statRows });
+    await scraper.scrapeOnce();
+    mocks.query.mockRejectedValueOnce(Object.assign(new Error("denied"), { code: "28P01" }));
 
-    it("is idempotent", async () => {
-      await stopPgBouncerScraper();
-      await stopPgBouncerScraper();
-    });
+    await expect(scraper.scrapeOnce()).resolves.toBe(false);
+    const output = await metricsRegistry.metrics();
+    expect(output).toContain("pgbouncer_scrape_success 0");
+    expect(output).toContain('pgbouncer_scrape_errors_total{reason="authentication"} 1');
+    expect(output).toContain('pgbouncer_waiting_clients{database="app",user="app_user"} 2');
+  });
+
+  it("does not overlap an in-progress scrape", async () => {
+    let resolveFirst!: (value: { rows: typeof poolRows }) => void;
+    mocks.query.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+    mocks.query.mockResolvedValueOnce({ rows: statRows });
+    const first = scraper.scrapeOnce();
+    await expect(scraper.scrapeOnce()).resolves.toBe(false);
+    resolveFirst({ rows: poolRows });
+    await expect(first).resolves.toBe(true);
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a non-PostgreSQL admin URL", () => {
+    mocks.config.pgbouncerMetrics.adminUrl = "https://localhost/pgbouncer";
+    expect(() => scraper.getPgBouncerAdminUrl()).toThrow("must use postgres or postgresql");
+  });
+
+  it("supports legacy stats columns and sanitizes missing or invalid values", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [{ database: " ", user: null, cl_waiting: -1, maxwait: "bad" }] })
+      .mockResolvedValueOnce({ rows: [{ database: null, total_requests: 7, total_query_time: "", avg_query: 1000 }] });
+    expect(await scraper.scrapeOnce()).toBe(true);
+    const output = await metricsRegistry.metrics();
+    expect(output).toContain('pgbouncer_waiting_clients{database="unknown",user="unknown"} 0');
+    expect(output).toContain('pgbouncer_total_requests{database="unknown"} 7');
+    expect(output).toContain('pgbouncer_avg_query_time_seconds{database="unknown"} 0.001');
+  });
+
+  it.each([
+    ["ETIMEDOUT", "timeout"],
+    ["ECONNREFUSED", "connection"],
+    ["42601", "query"],
+    [undefined, "unknown"],
+  ])("classifies %s scrape failures", async (code, reason) => {
+    const error = code ? Object.assign(new Error("failed"), { code }) : new Error("failed");
+    mocks.query.mockRejectedValueOnce(error);
+    expect(await scraper.scrapeOnce()).toBe(false);
+    expect(await metricsRegistry.metrics()).toContain(`pgbouncer_scrape_errors_total{reason="${reason}"} 1`);
+  });
+
+  it("redacts asynchronous pool error details", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    await scraper.scrapeOnce();
+    const handler = mocks.on.mock.calls.find(([event]) => event === "error")?.[1];
+    expect(handler).toBeTypeOf("function");
+    expect(() => handler(Object.assign(new Error("contains secret"), { code: "ECONNRESET" }))).not.toThrow();
+  });
+
+  it("honors upper and lower configuration bounds", () => {
+    mocks.config.pgbouncerMetrics.scrapeIntervalMs = 999_999;
+    mocks.config.pgbouncerMetrics.queryTimeoutMs = 1;
+    expect(scraper.getPgBouncerScrapeIntervalMs()).toBe(scraper.MAX_SCRAPE_INTERVAL_MS);
+    expect(scraper.getPgBouncerQueryTimeoutMs()).toBe(scraper.MIN_QUERY_TIMEOUT_MS);
+  });
+
+  it("exercises production lifecycle wrappers", async () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    process.env.METRICS_ENABLED = "true";
+    mocks.query.mockResolvedValue({ rows: [] });
+    scraper.startPgBouncerScraperIfNeeded();
+    await scraper.stopPgBouncerScraperIfNeeded();
+    process.env.NODE_ENV = original;
+    delete process.env.METRICS_ENABLED;
+    expect(mocks.end).toHaveBeenCalledOnce();
+  });
+
+  it("starts once and closes its one-connection pool idempotently", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    expect(scraper.startPgBouncerScraper()).toBe(true);
+    expect(scraper.startPgBouncerScraper()).toBe(false);
+    await scraper.stopPgBouncerScraper();
+    await scraper.stopPgBouncerScraper();
+    expect(mocks.end).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Scrape SHOW POOLS and SHOW STATS through a bounded, single-connection PgBouncer admin client and publish pool, queue, query, and scraper-health gauges through the existing prom-client registry.

Add secure least-privilege configuration, non-overlapping scheduling, failure fallback, recording and alerting rules, operational documentation, and high-coverage tests.

Closes #508