### PR TITLE
feat: detect cloud resource attributes for OTel (Issue #536)

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -9,6 +9,7 @@ import {
   type Span,
 } from "@opentelemetry/api";
 import type { Request, Response } from "express";
+import { readFile } from 'node:fs/promises';
 import { logger } from "./utils/logger.js";
 
 export const ALLOWED_BAGGAGE_KEYS = new Set(["tenant.id"]);
@@ -21,6 +22,268 @@ type OpenTelemetrySdk = {
 let sdk: OpenTelemetrySdk | undefined;
 let sdkStarted = false;
 let sdkStartPromise: Promise<OpenTelemetrySdk | undefined> | undefined;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cloud Provider Resource Detection
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Detects cloud provider metadata (AWS, GCP, Kubernetes) and attaches
+// resource attributes to every span so infra dashboards can correlate
+// traces with hosts, regions, and clusters.
+//
+// Each detector is guarded by a configurable timeout
+// (CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS, default 1000 ms) and a dedicated
+// AbortController. Detection failures never block startup — the SDK starts
+// with whatever attributes were collected before the deadline.
+
+/** Default per-detector timeout in milliseconds. */
+export const DEFAULT_CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = 1_000
+
+/** Maximum timeout to prevent misconfiguration from delaying boot. */
+export const MAX_CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = 5_000
+
+/** Resolved attributes keyed by cloud.* / k8s.* / host.* convention. */
+export type CloudResourceAttributes = Record<string, string>
+
+/** Catalogue of resolved cloud attributes. */
+export type CloudResourceDetectionResult = {
+  provider: 'aws' | 'gcp' | 'kubernetes' | 'unknown'
+  attributes: CloudResourceAttributes
+}
+
+/**
+ * Resolve the per-detector timeout from env.
+ *
+ * Uses `CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS` (default 1000 ms),
+ * clamped to [100, MAX_CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS].
+ */
+export function resolveCloudDetectorTimeoutMs(): number {
+  const raw = process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS
+  const parsed = raw != null && raw !== '' ? Number(raw) : NaN
+  const candidate = Number.isFinite(parsed) ? parsed : DEFAULT_CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS
+  return Math.max(100, Math.min(MAX_CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS, candidate))
+}
+
+/**
+ * Run a detector function with an AbortSignal timeout.
+ *
+ * Returns `attributes` when the detector completes within the deadline;
+ * returns an empty object when the deadline expires or the detector throws.
+ *
+ * @param detector - Async function that returns a partial attributes map.
+ * @param timeoutMs - Per-detector timeout in ms.
+ * @param label    - Short label for observability (e.g. "aws", "gcp").
+ */
+async function detectWithTimeout(
+  detector: (signal: AbortSignal) => Promise<CloudResourceAttributes>,
+  timeoutMs: number,
+  label: string,
+): Promise<CloudResourceAttributes> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    if (timer && typeof timer.unref === 'function') timer.unref()
+    return await detector(controller.signal)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logger.debug({
+      event: 'cloud_resource_detector_failed',
+      provider: label,
+      error: message,
+    })
+    return {}
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ─── AWS EC2 Metadata detector ─────────────────────────────────────────────
+
+const AWS_METADATA_BASE = 'http://169.254.169.254/latest/meta-data'
+
+/**
+ * Detect AWS resource attributes via the EC2 Instance Metadata Service
+ * (IMDSv1 for broadest compatibility; IMDSv2 token retrieval is optional
+ * but adds an extra round-trip that risks exceeding the timeout).
+ */
+export async function detectAwsResources(
+  signal: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CloudResourceAttributes> {
+  if (signal.aborted) return {}
+
+  const attrs: CloudResourceAttributes = {}
+
+  try {
+    const [instanceId, instanceType, region, az, accountId] = await Promise.all([
+      fetchImpl(`${AWS_METADATA_BASE}/instance-id`, { signal }).then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${AWS_METADATA_BASE}/instance-type`, { signal }).then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${AWS_METADATA_BASE}/placement/region`, { signal })
+        .then(r => r.ok ? r.text() : '')
+        .catch(() => ''),
+      fetchImpl(`${AWS_METADATA_BASE}/placement/availability-zone`, { signal }).then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${AWS_METADATA_BASE}/identity-credentials/ec2/info`, { signal })
+        .then(r => r.ok ? r.json() as { AccountId?: string } : null)
+        .then(v => v?.AccountId ?? '')
+        .catch(() => ''),
+    ])
+
+    if (instanceId) attrs['cloud.provider'] = 'aws'
+    if (instanceId) attrs['cloud.platform'] = 'aws_ec2'
+    if (instanceId) attrs['host.id'] = instanceId
+    if (instanceType) attrs['host.type'] = instanceType
+    if (region) attrs['cloud.region'] = region
+    if (az) attrs['cloud.availability_zone'] = az
+    if (accountId) attrs['cloud.account.id'] = accountId
+  } catch {
+    // Timeout or network error — return whatever we collected (likely empty)
+  }
+
+  return attrs
+}
+
+// ─── GCP Compute Engine Metadata detector ──────────────────────────────────
+
+const GCP_METADATA_BASE = 'http://metadata.google.internal/computeMetadata/v1'
+
+/**
+ * Detect GCP resource attributes via the Compute Engine Metadata Server.
+ *
+ * Requires the `Metadata-Flavor: Google` header per GCP security
+ * requirements. Falls back gracefully when run outside GCP.
+ */
+export async function detectGcpResources(
+  signal: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CloudResourceAttributes> {
+  if (signal.aborted) return {}
+
+  const attrs: CloudResourceAttributes = {}
+  const headers = { 'Metadata-Flavor': 'Google' }
+
+  try {
+    const [instanceId, instanceName, zone, projectId] = await Promise.all([
+      fetchImpl(`${GCP_METADATA_BASE}/instance/id`, { signal, headers })
+        .then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${GCP_METADATA_BASE}/instance/name`, { signal, headers })
+        .then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${GCP_METADATA_BASE}/instance/zone`, { signal, headers })
+        .then(r => r.ok ? r.text() : ''),
+      fetchImpl(`${GCP_METADATA_BASE}/project/project-id`, { signal, headers })
+        .then(r => r.ok ? r.text() : ''),
+    ])
+
+    // Extract region from zone (projects/PROJECT/zones/us-central1-a → us-central1)
+    const region = zone ? zone.split('/').pop()?.replace(/-[a-z]$/, '') ?? '' : ''
+
+    if (instanceId) attrs['cloud.provider'] = 'gcp'
+    if (instanceId) attrs['cloud.platform'] = 'gcp_compute_engine'
+    if (instanceId) attrs['host.id'] = instanceId
+    if (instanceName) attrs['host.name'] = instanceName
+    if (region) attrs['cloud.region'] = region
+    if (zone) attrs['cloud.availability_zone'] = zone.split('/').pop() ?? zone
+    if (projectId) attrs['cloud.account.id'] = projectId
+  } catch {
+    // Timeout or network error
+  }
+
+  return attrs
+}
+
+// ─── Kubernetes detector ───────────────────────────────────────────────────
+
+/**
+ * Detect Kubernetes resource attributes from the downwards API and
+ * container runtime cgroups.
+ *
+ * This is a lightweight detector that does not require the k8s client
+ * library — it reads env vars and /proc/self/cgroup, both of which are
+ * available inside any Pod without extra dependencies.
+ */
+export async function detectKubernetesResources(
+  signal: AbortSignal,
+  readFileImpl: (path: string) => Promise<string> = (p) => readFile(p, 'utf-8'),
+): Promise<CloudResourceAttributes> {
+  const attrs: CloudResourceAttributes = {}
+
+  if (signal.aborted) return attrs
+
+  const podName = process.env.KUBERNETES_POD_NAME ?? process.env.HOSTNAME ?? ''
+  const namespace = process.env.KUBERNETES_NAMESPACE ?? ''
+  const nodeName = process.env.KUBERNETES_NODE_NAME ?? ''
+
+  if (podName) attrs['k8s.pod.name'] = podName
+  if (namespace) attrs['k8s.namespace.name'] = namespace
+  if (nodeName) attrs['k8s.node.name'] = nodeName
+  if (podName) attrs['cloud.provider'] = attrs['cloud.provider'] ?? 'kubernetes'
+
+  // Container ID from cgroup (first line matching /kubepods/...)
+  try {
+    const cgroup = await readFileImpl('/proc/self/cgroup')
+    if (!signal.aborted) {
+      for (const line of cgroup.split('\n')) {
+        const parts = line.split(':')
+        if (parts.length < 3) continue
+        const path = parts[2] ?? ''
+        // /kubepods/besteffort/pod<UID>/<container-id> OR /kubepods/burstable/...
+        const match = path.match(/\/kubepods\/[^/]+\/pod[^/]+\/([0-9a-f]{64})/)
+        if (match) {
+          attrs['container.id'] = match[1]
+          break
+        }
+        // Docker runtime: /docker/<container-id>
+        const dockerMatch = path.match(/\/docker\/([0-9a-f]{64})/)
+        if (dockerMatch) {
+          attrs['container.id'] = dockerMatch[1]
+          break
+        }
+      }
+    }
+  } catch {
+    // /proc/self/cgroup may not be readable (e.g. non-Linux)
+  }
+
+  return attrs
+}
+
+/**
+ * Run all cloud resource detectors in parallel with individual timeouts.
+ *
+ * Each detector is given `timeoutMs` to complete. The function returns
+ * the merged attributes from any detectors that finish within the deadline.
+ * When no detector returns attributes the result's `provider` is "unknown".
+ *
+ * This is the public entrypoint called during SDK initialisation.
+ */
+export async function detectCloudResources(
+  timeoutMs: number = resolveCloudDetectorTimeoutMs(),
+  fetchImpl: typeof fetch = fetch,
+  readFileImpl: (path: string) => Promise<string> = (p) => readFile(p, 'utf-8'),
+): Promise<CloudResourceDetectionResult> {
+  const [awsAttrs, gcpAttrs, k8sAttrs] = await Promise.all([
+    detectWithTimeout((s) => detectAwsResources(s, fetchImpl), timeoutMs, 'aws'),
+    detectWithTimeout((s) => detectGcpResources(s, fetchImpl), timeoutMs, 'gcp'),
+    detectWithTimeout((s) => detectKubernetesResources(s, readFileImpl), timeoutMs, 'kubernetes'),
+  ])
+
+  // Merge: later detectors do NOT overwrite keys set by earlier ones
+  const merged: CloudResourceAttributes = {}
+  for (const attrs of [awsAttrs, gcpAttrs, k8sAttrs]) {
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v && !(k in merged)) merged[k] = v
+    }
+  }
+
+  const provider =
+    merged['cloud.provider'] === 'aws' ? 'aws' :
+    merged['cloud.provider'] === 'gcp' ? 'gcp' :
+    merged['k8s.pod.name'] ? 'kubernetes' :
+    'unknown'
+
+  return { provider, attributes: merged }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 
 const HTTP_HEADER_GETTER = {
   get(carrier: Request["headers"], key: string) {
@@ -82,8 +345,33 @@ export async function initializeOpenTelemetry(): Promise<
     );
     const traceExporter = new SanitizingSpanExporter(rawExporter);
 
+    // Import Resource type for cloud-provider detection integration.
+    const { Resource } = await import("@opentelemetry/resources");
+
+    // Detect cloud-provider resource attributes with timeout guards.
+    // Detection NEVER blocks startup — the SDK starts with whatever
+    // attributes were collected before the combined deadline.
+    let resourceAttributes: Record<string, string> = {};
+    try {
+      const detection = await detectCloudResources();
+      if (detection.provider !== 'unknown') {
+        resourceAttributes = detection.attributes;
+        logger.info({
+          event: 'cloud_resource_detected',
+          provider: detection.provider,
+          attributeCount: Object.keys(resourceAttributes).length,
+        });
+      }
+    } catch (detectErr) {
+      logger.debug({
+        event: 'cloud_resource_detection_skipped',
+        error: detectErr instanceof Error ? detectErr.message : String(detectErr),
+      });
+    }
+
     sdk = new NodeSDK({
       serviceName: process.env.OTEL_SERVICE_NAME ?? "veritasor-backend",
+      resource: new Resource(resourceAttributes),
       traceExporter,
       logRecordProcessor: new BatchLogRecordProcessor(logExporter),
     });

--- a/tests/unit/tracing-resource-detection.test.ts
+++ b/tests/unit/tracing-resource-detection.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Reset all mocks before importing the module under test
+let tracingMod: typeof import('../../src/tracing.js')
+const originalEnv = { ...process.env }
+
+async function importTracing() {
+  // Dynamic import so env is read fresh
+  tracingMod = await import('../../src/tracing.js')
+  return tracingMod
+}
+
+describe('resolveCloudDetectorTimeoutMs', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    delete process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS
+    await importTracing()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('returns the default 1000 ms when env is unset', () => {
+    expect(tracingMod.resolveCloudDetectorTimeoutMs()).toBe(1000)
+  })
+
+  it('reads CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS from the environment', () => {
+    process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = '2000'
+    expect(tracingMod.resolveCloudDetectorTimeoutMs()).toBe(2000)
+  })
+
+  it('clamps below the minimum (100 ms)', () => {
+    process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = '5'
+    expect(tracingMod.resolveCloudDetectorTimeoutMs()).toBe(100)
+  })
+
+  it('clamps above the maximum (5000 ms)', () => {
+    process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = '60000'
+    expect(tracingMod.resolveCloudDetectorTimeoutMs()).toBe(5000)
+  })
+
+  it('falls back to default when env is non-numeric', () => {
+    process.env.CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS = 'abc'
+    expect(tracingMod.resolveCloudDetectorTimeoutMs()).toBe(1000)
+  })
+})
+
+describe('detectAwsResources', () => {
+  let fetchImpl: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    await importTracing()
+    fetchImpl = vi.fn()
+  })
+
+  it('returns empty attributes when fetch times out (AbortError)', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const attrs = await tracingMod.detectAwsResources(controller.signal, fetchImpl)
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(attrs).toEqual({})
+  })
+
+  it('returns AWS attributes when metadata service responds', async () => {
+    fetchImpl
+      .mockResolvedValueOnce({ ok: true, text: async () => 'i-abc123' })       // instance-id
+      .mockResolvedValueOnce({ ok: true, text: async () => 't3.medium' })        // instance-type
+      .mockResolvedValueOnce({ ok: true, text: async () => 'us-east-1' })        // region
+      .mockResolvedValueOnce({ ok: true, text: async () => 'us-east-1a' })       // az
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ AccountId: '123456789012' }) }) // account
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectAwsResources(controller.signal, fetchImpl)
+    expect(attrs).toMatchObject({
+      'cloud.provider': 'aws',
+      'cloud.platform': 'aws_ec2',
+      'host.id': 'i-abc123',
+      'host.type': 't3.medium',
+      'cloud.region': 'us-east-1',
+      'cloud.availability_zone': 'us-east-1a',
+      'cloud.account.id': '123456789012',
+    })
+  })
+
+  it('returns empty when all responses are not ok', async () => {
+    fetchImpl.mockResolvedValue({ ok: false })
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectAwsResources(controller.signal, fetchImpl)
+    expect(attrs).toEqual({})
+  })
+})
+
+describe('detectGcpResources', () => {
+  let fetchImpl: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    await importTracing()
+    fetchImpl = vi.fn()
+  })
+
+  it('returns empty when aborted before calls', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const attrs = await tracingMod.detectGcpResources(controller.signal, fetchImpl)
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(attrs).toEqual({})
+  })
+
+  it('returns GCP attributes when metadata server responds', async () => {
+    fetchImpl
+      .mockResolvedValueOnce({ ok: true, text: async () => '1234567890123456789' })      // instance-id
+      .mockResolvedValueOnce({ ok: true, text: async () => 'my-gce-instance' })          // instance-name
+      .mockResolvedValueOnce({ ok: true, text: async () => 'projects/my-project/zones/us-central1-a' }) // zone
+      .mockResolvedValueOnce({ ok: true, text: async () => 'my-project' })               // project-id
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectGcpResources(controller.signal, fetchImpl)
+    expect(attrs).toMatchObject({
+      'cloud.provider': 'gcp',
+      'cloud.platform': 'gcp_compute_engine',
+      'host.id': '1234567890123456789',
+      'host.name': 'my-gce-instance',
+      'cloud.region': 'us-central1',
+      'cloud.account.id': 'my-project',
+    })
+  })
+})
+
+describe('detectKubernetesResources', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    await importTracing()
+    delete process.env.KUBERNETES_POD_NAME
+    delete process.env.KUBERNETES_NAMESPACE
+    delete process.env.KUBERNETES_NODE_NAME
+    delete process.env.HOSTNAME
+  })
+
+  it('returns empty when no K8s env vars are set and /proc is unreadable', async () => {
+    const readFileImpl = vi.fn().mockRejectedValue(new Error('ENOENT'))
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectKubernetesResources(controller.signal, readFileImpl)
+    expect(attrs).toEqual({})
+  })
+
+  it('extracts pod name from KUBERNETES_POD_NAME', async () => {
+    process.env.KUBERNETES_POD_NAME = 'my-pod-abc'
+    process.env.KUBERNETES_NAMESPACE = 'default'
+    const readFileImpl = vi.fn().mockRejectedValue(new Error('ENOENT'))
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectKubernetesResources(controller.signal, readFileImpl)
+    expect(attrs).toMatchObject({
+      'k8s.pod.name': 'my-pod-abc',
+      'k8s.namespace.name': 'default',
+      'cloud.provider': 'kubernetes',
+    })
+  })
+
+  it('extracts container ID from cgroup with kubepods path', async () => {
+    process.env.KUBERNETES_POD_NAME = 'my-pod'
+    const cgroupContent = [
+      '12:memory:/kubepods/burstable/pod123abc/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      '11:cpu:/kubepods/burstable/pod123abc',
+    ].join('\n')
+    const readFileImpl = vi.fn().mockResolvedValue(cgroupContent)
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectKubernetesResources(controller.signal, readFileImpl)
+    expect(attrs).toMatchObject({
+      'k8s.pod.name': 'my-pod',
+      'container.id': '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    })
+  })
+
+  it('extracts container ID from docker cgroup path', async () => {
+    const containerId = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    const cgroupContent = [
+      `1:name=systemd:/docker/${containerId}`,
+    ].join('\n')
+    const readFileImpl = vi.fn().mockResolvedValue(cgroupContent)
+
+    const controller = new AbortController()
+    const attrs = await tracingMod.detectKubernetesResources(controller.signal, readFileImpl)
+    expect(attrs).toEqual({
+      'container.id': containerId,
+    })
+  })
+
+  it('returns empty when aborted before cgroup read', async () => {
+    process.env.KUBERNETES_POD_NAME = 'my-pod'
+    const readFileImpl = vi.fn()
+    const controller = new AbortController()
+    controller.abort()
+
+    const attrs = await tracingMod.detectKubernetesResources(controller.signal, readFileImpl)
+    expect(readFileImpl).not.toHaveBeenCalled()
+    expect(attrs).toEqual({})
+  })
+})
+
+describe('detectCloudResources', () => {
+  let fetchImpl: ReturnType<typeof vi.fn>
+  let readFileImpl: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+    await importTracing()
+    fetchImpl = vi.fn()
+    readFileImpl = vi.fn()
+    delete process.env.KUBERNETES_POD_NAME
+    delete process.env.KUBERNETES_NAMESPACE
+    delete process.env.HOSTNAME
+  })
+
+  it('returns provider "unknown" when all detectors return empty', async () => {
+    fetchImpl.mockResolvedValue({ ok: false })
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await tracingMod.detectCloudResources(500, fetchImpl, readFileImpl)
+    expect(result.provider).toBe('unknown')
+    expect(result.attributes).toEqual({})
+  })
+
+  it('returns provider "aws" when AWS detector finds attributes', async () => {
+    fetchImpl
+      // AWS calls
+      .mockResolvedValueOnce({ ok: true, text: async () => 'i-test' })        // instance-id
+      .mockResolvedValueOnce({ ok: true, text: async () => 't3.small' })       // instance-type
+      .mockResolvedValueOnce({ ok: true, text: async () => 'us-west-2' })      // region
+      .mockResolvedValueOnce({ ok: true, text: async () => 'us-west-2a' })     // az
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ AccountId: '123' }) }) // account
+      // GCP calls — all fail
+      .mockRejectedValue(new Error('ECONNREFUSED'))
+      .mockRejectedValue(new Error('ECONNREFUSED'))
+      .mockRejectedValue(new Error('ECONNREFUSED'))
+      .mockRejectedValue(new Error('ECONNREFUSED'))
+
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await tracingMod.detectCloudResources(500, fetchImpl, readFileImpl)
+    expect(result.provider).toBe('aws')
+    expect(result.attributes['host.id']).toBe('i-test')
+  })
+
+  it('returns provider "gcp" when GCP detector finds attributes', async () => {
+    // Use URL-based mock to avoid race conditions with parallel detectors
+    fetchImpl.mockImplementation(async (url: string, opts?: { signal?: AbortSignal }) => {
+      // AWS metadata returns not-ok (these won't be reached normally but handle them)
+      if (String(url).includes('169.254.169.254')) {
+        return { ok: false }
+      }
+      // GCP metadata returns ok
+      if (String(url).includes('metadata.google.internal')) {
+        const path = String(url).replace('http://metadata.google.internal/computeMetadata/v1', '')
+        if (path === '/instance/id') return { ok: true, text: async () => 'gcp-instance-1' }
+        if (path === '/instance/name') return { ok: true, text: async () => 'my-instance' }
+        if (path === '/instance/zone') return { ok: true, text: async () => 'projects/p/zones/us-east1-b' }
+        if (path === '/project/project-id') return { ok: true, text: async () => 'my-proj' }
+      }
+      return { ok: false }
+    })
+
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await tracingMod.detectCloudResources(500, fetchImpl, readFileImpl)
+    expect(result.provider).toBe('gcp')
+    expect(result.attributes['host.id']).toBe('gcp-instance-1')
+  })
+
+  it('returns provider "kubernetes" when K8s detector finds pod name', async () => {
+    fetchImpl.mockRejectedValue(new Error('ECONNREFUSED'))
+    process.env.KUBERNETES_POD_NAME = 'my-pod-xyz'
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await tracingMod.detectCloudResources(500, fetchImpl, readFileImpl)
+    expect(result.provider).toBe('kubernetes')
+    expect(result.attributes['k8s.pod.name']).toBe('my-pod-xyz')
+  })
+
+  it('returns before the timeout even when a detector hangs', async () => {
+    // GCP detector hangs, but returns on abort
+    fetchImpl
+      .mockImplementation((_url: string, opts: { signal: AbortSignal }) => {
+        return new Promise<{ ok: boolean; text: () => Promise<string> }>((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+        })
+      })
+
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const start = Date.now()
+    await tracingMod.detectCloudResources(200, fetchImpl, readFileImpl)
+    const elapsed = Date.now() - start
+    // Should complete within roughly the timeout
+    expect(elapsed).toBeLessThan(500)
+  })
+
+  it('provider precedence: aws > gcp > kubernetes', async () => {
+    // All three detectors return attributes — use URL-based mock
+    fetchImpl.mockImplementation(async (url: string, opts?: { signal?: AbortSignal }) => {
+      if (String(url).includes('169.254.169.254')) {
+        const path = String(url).replace('http://169.254.169.254/latest/meta-data', '')
+        if (path === '/instance-id') return { ok: true, text: async () => 'aws-instance' }
+        if (path === '/instance-type') return { ok: true, text: async () => 'm5.large' }
+        if (path === '/placement/region') return { ok: true, text: async () => 'eu-west-1' }
+        if (path === '/placement/availability-zone') return { ok: true, text: async () => 'eu-west-1a' }
+        if (path === '/identity-credentials/ec2/info') return { ok: true, json: async () => ({ AccountId: 'aws-acct' }) }
+      }
+      if (String(url).includes('metadata.google.internal')) {
+        const path = String(url).replace('http://metadata.google.internal/computeMetadata/v1', '')
+        if (path === '/instance/id') return { ok: true, text: async () => 'gcp-instance' }
+        if (path === '/instance/name') return { ok: true, text: async () => 'gcp-name' }
+        if (path === '/instance/zone') return { ok: true, text: async () => 'projects/p/zones/us-east1-b' }
+        if (path === '/project/project-id') return { ok: true, text: async () => 'gcp-proj' }
+      }
+      return { ok: false }
+    })
+
+    process.env.KUBERNETES_POD_NAME = 'k8s-pod'
+    readFileImpl.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await tracingMod.detectCloudResources(500, fetchImpl, readFileImpl)
+    expect(result.provider).toBe('aws')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #536

### Changes
- Add **detectAwsResources**, **detectGcpResources**, **detectKubernetesResources** with per-detector AbortSignal timeout guards
- Add **detectCloudResources** orchestrator that runs all detectors in parallel with configurable timeout (CLOUD_RESOURCE_DETECTOR_TIMEOUT_MS)
- Integrate detection into **initializeOpenTelemetry** via `@opentelemetry/resources` Resource
- Detection never blocks startup: timeout/errors are swallowed gracefully
- Add 21 unit tests + 4 existing tracing tests continue to pass

### Verification
- `npx vitest run tests/unit/tracing-resource-detection.test.ts tests/unit/tracing.test.ts` — 25 tests pass