### PR TITLE
feat: honor conditional requests on public attestation reads

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -384,6 +384,13 @@ export const statsdDualWriteDurationMs = new Histogram({
   registers: [metricsRegistry],
 });
 
+export const etagHitsTotal = new Counter({
+  name: "etag_hits_total",
+  help: "Total number of ETag-based cache decisions (hit = 304 served, miss = full response)",
+  labelNames: ["route", "result"] as const,
+  registers: [metricsRegistry],
+});
+
 export const statsdDualWriteMetricsCount = new Gauge({
   name: 'statsd_dual_write_metrics_count',
   help: 'Number of Prometheus metric values mirrored in the most recent StatsD dual-write cycle',

--- a/src/routes/publicAttestations.ts
+++ b/src/routes/publicAttestations.ts
@@ -1,21 +1,43 @@
+import crypto from 'node:crypto';
 import { Request, Response, Router } from 'express';
 import { z } from 'zod';
 import * as attestationRepository from '../repositories/attestationRepository.js';
 import { db } from '../db/client.js';
 import { AppError } from '../types/errors.js';
 import { formatCacheControl, CACHE_POLICIES } from '../utils/cachePolicy.js';
+import { etagHitsTotal } from '../metrics.js';
 
 const hashParamSchema = z.string().min(1).max(512);
 
 export const publicAttestationsRouter = Router();
 
-// Resolve cache policy entries for this route once at module load
 const activePolicy = CACHE_POLICIES.find(
   (p) => p.name === 'public-attestations-active',
 );
 const revokedPolicy = CACHE_POLICIES.find(
   (p) => p.name === 'public-attestations-revoked',
 );
+
+function sortObjectKeys(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.keys(obj).sort().reduce<Record<string, unknown>>((acc, key) => {
+    acc[key] = obj[key];
+    return acc;
+  }, {});
+}
+
+function computeEtag(payload: Record<string, unknown>): string {
+  const sorted = sortObjectKeys(payload);
+  const hash = crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('base64');
+  return `"${hash}"`;
+}
+
+function matchEtag(ifNoneMatch: string | undefined, etag: string): boolean {
+  if (!ifNoneMatch) return false;
+  const candidates = ifNoneMatch.split(',').map((s) => s.trim());
+  const stripWeak = (s: string) => (s.startsWith('W/') ? s.slice(2) : s);
+  const target = stripWeak(etag);
+  return candidates.some((c) => stripWeak(c) === target);
+}
 
 publicAttestationsRouter.get(
   '/:hash',
@@ -42,7 +64,7 @@ publicAttestationsRouter.get(
         'Cache-Control': revokedPolicy
           ? formatCacheControl(revokedPolicy.directives)
           : 'public, max-age=15, stale-while-revalidate=60',
-        'Age': '0'
+        'Age': '0',
       });
       res.status(410).json({
         status: 'error',
@@ -62,22 +84,24 @@ publicAttestationsRouter.get(
       attestedAt: attestation.createdAt.toISOString(),
     };
 
-    const etag = `"${Buffer.from(JSON.stringify(payload)).toString('base64').slice(0, 32)}"`;
+    const etag = computeEtag(payload);
     const lastModified = attestation.createdAt.toUTCString();
 
-    if (req.headers['if-none-match'] === etag) {
+    if (matchEtag(req.headers['if-none-match'], etag)) {
+      etagHitsTotal.inc({ route: 'publicAttestations', result: 'hit' });
       res.status(304).end();
       return;
     }
 
-    setCacheControl(res, CachePolicies.PUBLIC_ATTESTATION_ACTIVE);
+    etagHitsTotal.inc({ route: 'publicAttestations', result: 'miss' });
+
     res.set({
       'Cache-Control': activePolicy
         ? formatCacheControl(activePolicy.directives)
         : 'public, max-age=60, stale-while-revalidate=60',
       'ETag': etag,
       'Last-Modified': lastModified,
-      'Age': '0'
+      'Age': '0',
     });
 
     res.status(200).json({

--- a/tests/unit/routes/publicAttestations.test.ts
+++ b/tests/unit/routes/publicAttestations.test.ts
@@ -1,0 +1,169 @@
+import crypto from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mockGetById = vi.fn();
+vi.mock('../../../src/repositories/attestationRepository.js', () => ({
+  getById: mockGetById,
+}));
+
+vi.mock('../../../src/db/client.js', () => ({
+  db: { query: vi.fn() },
+}));
+
+const { publicAttestationsRouter } = await import(
+  '../../../src/routes/publicAttestations.js'
+);
+
+const app = express();
+app.use('/public/attestations', publicAttestationsRouter);
+
+function makeAttestation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'att_001',
+    businessId: 'biz_001',
+    period: '2026-07',
+    merkleRoot: 'abc123',
+    txHash: '0xtx',
+    status: 'confirmed',
+    createdAt: new Date('2026-07-15T12:00:00Z'),
+    updatedAt: new Date('2026-07-15T12:00:00Z'),
+    version: 1,
+    ...overrides,
+  };
+}
+
+function expectedEtag(attestation: ReturnType<typeof makeAttestation>): string {
+  const payload = {
+    id: attestation.id,
+    businessId: attestation.businessId,
+    period: attestation.period,
+    merkleRoot: attestation.merkleRoot,
+    txHash: attestation.txHash,
+    status: attestation.status,
+    attestedAt: attestation.createdAt.toISOString(),
+  };
+  const sorted = Object.keys(payload).sort().reduce<Record<string, unknown>>((acc, key) => {
+    acc[key] = payload[key as keyof typeof payload];
+    return acc;
+  }, {});
+  const hash = crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('base64');
+  return `"${hash}"`;
+}
+
+describe('GET /public/attestations/:hash', () => {
+  beforeEach(() => {
+    mockGetById.mockReset();
+  });
+
+  it('returns 200 with attestation payload', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+
+    const res = await request(app).get('/public/attestations/att_001');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.id).toBe('att_001');
+  });
+
+  it('sets ETag and Cache-Control headers on 200', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+
+    const res = await request(app).get('/public/attestations/att_001');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['etag']).toBeDefined();
+    expect(res.headers['cache-control']).toContain('public');
+    expect(res.headers['last-modified']).toBeDefined();
+  });
+
+  it('returns 304 when If-None-Match matches the computed ETag', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+    const etag = expectedEtag(att);
+
+    const res = await request(app)
+      .get('/public/attestations/att_001')
+      .set('If-None-Match', etag);
+
+    expect(res.status).toBe(304);
+    expect(res.body).toStrictEqual({});
+  });
+
+  it('returns 200 when If-None-Match does not match', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+
+    const res = await request(app)
+      .get('/public/attestations/att_001')
+      .set('If-None-Match', '"different-etag"');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('honours weak ETags (W/ prefix) in If-None-Match', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+    const etag = expectedEtag(att);
+
+    const res = await request(app)
+      .get('/public/attestations/att_001')
+      .set('If-None-Match', `W/${etag}`);
+
+    expect(res.status).toBe(304);
+  });
+
+  it('honours multiple ETags in If-None-Match', async () => {
+    const att = makeAttestation();
+    mockGetById.mockResolvedValue(att);
+    const etag = expectedEtag(att);
+
+    const res = await request(app)
+      .get('/public/attestations/att_001')
+      .set('If-None-Match', `"old-etag", ${etag}, "another-etag"`);
+
+    expect(res.status).toBe(304);
+  });
+
+  it('returns 404 when attestation is not found', async () => {
+    mockGetById.mockResolvedValue(null);
+
+    const res = await request(app).get('/public/attestations/nonexistent');
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 410 when attestation is revoked', async () => {
+    const att = makeAttestation({ status: 'revoked' });
+    mockGetById.mockResolvedValue(att);
+
+    const res = await request(app).get('/public/attestations/att_001');
+
+    expect(res.status).toBe(410);
+    expect(res.body.code).toBe('GONE');
+    expect(res.headers['cache-control']).toContain('max-age=15');
+  });
+
+  it('returns 400 for invalid hash', async () => {
+    const res = await request(app).get('/public/attestations/');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('produces stable ETag across serialization changes', () => {
+    const att = makeAttestation();
+    const etag1 = expectedEtag(att);
+    const etag2 = expectedEtag(makeAttestation({ id: 'att_001' }));
+    expect(etag1).toBe(etag2);
+  });
+
+  it('produces different ETag for different content', () => {
+    const att1 = makeAttestation({ id: 'att_001' });
+    const att2 = makeAttestation({ id: 'att_002' });
+    expect(expectedEtag(att1)).not.toBe(expectedEtag(att2));
+  });
+});


### PR DESCRIPTION
## Summary

Add strong ETag generation and honor conditional requests (`If-None-Match`) on public attestation lookup responses to save bandwidth and reduce origin load.

## Changes

- Replace ad-hoc base64-slice ETag with SHA-256 content hash for strong ETags
- Add deterministic JSON key ordering for stable ETags across serialization changes
- Handle weak ETags (`W/` prefix) and multiple ETags in `If-None-Match`
- Add `etag_hits_total` Prometheus counter for hit-ratio observability
- Remove redundant `setCacheControl` call (Cache-Control already set inline from cache policy)
- Add comprehensive unit tests covering 304, weak ETags, multi-ETag, 404, 410, and ETag stability

Closes #494