### PR TITLE
feat: webhook subscription CRUD with event filters

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,7 @@ import { jwksManager } from "./utils/jwks.js";
 import { formatCacheControl, CACHE_POLICIES } from "./utils/cachePolicy.js";
 import { razorpayWebhookRouter } from "./routes/webhooks-razorpay.js";
 import { webhookEgressIpsRouter } from "./routes/webhookEgressIps.js";
+import { webhookSubscriptionsRouter } from "./routes/webhook-subscriptions.js";
 import adminRouter from "./routes/admin.js";
 import adminGraphqlRouter from "./routes/admin.graphql.js";
 import {
@@ -102,6 +103,9 @@ export function createApp(readinessReport: StartupReadinessReport): Express {
   // 3. Body Parsing
   app.use(express.json());
   app.use(createCorsMiddleware());
+
+  // Webhook subscription CRUD API (after body parsing)
+  app.use("/api/v1/webhook-subscriptions", webhookSubscriptionsRouter);
 
   // Response compression (brotli preferred, gzip fallback) with a BREACH guard
   // that refuses to compress responses carrying CSRF tokens or session cookies.

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -260,6 +260,13 @@ export class PgClient {
 // Export a singleton instance
 let pgClient: PgClient | null = null;
 
+/** Lazy singleton database client. */
+export const db: PgClient = new Proxy({} as PgClient, {
+  get(_target, prop) {
+    return (getPgClient() as Record<string, unknown>)[prop as string];
+  },
+});
+
 export function getPgClient(): PgClient {
   if (!pgClient) {
     pgClient = new PgClient({

--- a/src/db/migrations/20260729_001_create_webhook_subscriptions_table.down.sql
+++ b/src/db/migrations/20260729_001_create_webhook_subscriptions_table.down.sql
@@ -1,0 +1,4 @@
+-- Migration: 20260729_001_create_webhook_subscriptions_table (down)
+-- Drops the webhook_subscriptions table and its indexes.
+
+DROP TABLE IF EXISTS webhook_subscriptions CASCADE;

--- a/src/db/migrations/20260729_001_create_webhook_subscriptions_table.sql
+++ b/src/db/migrations/20260729_001_create_webhook_subscriptions_table.sql
@@ -1,0 +1,24 @@
+-- Migration: 20260729_001_create_webhook_subscriptions_table
+-- Creates webhook_subscriptions table for persistent webhook subscription management
+-- with per-event filter DSL stored as JSONB.
+
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id       TEXT NOT NULL,
+  url               TEXT NOT NULL,
+  secret            TEXT NOT NULL,
+  event_filters     JSONB DEFAULT '{}'::jsonb,
+  enabled           BOOLEAN NOT NULL DEFAULT true,
+  max_payload_size  INTEGER,
+  secret_version    INTEGER NOT NULL DEFAULT 1,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subs_business_id ON webhook_subscriptions(business_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_subs_business_url ON webhook_subscriptions(business_id, url);
+
+COMMENT ON TABLE webhook_subscriptions IS 'Persistent webhook subscriptions with per-event filter DSL';
+COMMENT ON COLUMN webhook_subscriptions.event_filters IS 'JSONB map of event types to boolean or filter objects. e.g. {"attestation.created":true,"attestation.updated":{"status":"completed"}}';
+COMMENT ON COLUMN webhook_subscriptions.secret_version IS 'Monotonically increasing version for HMAC secret rotation tracking';
+COMMENT ON COLUMN webhook_subscriptions.max_payload_size IS 'Optional max payload size in bytes. Exceeding this causes delivery rejection.';

--- a/src/repositories/webhookSubscriptionRepository.ts
+++ b/src/repositories/webhookSubscriptionRepository.ts
@@ -1,0 +1,202 @@
+import { db } from "../db/client.js";
+import type {
+  EventFilters,
+  CreateWebhookSubscriptionInput,
+  UpdateWebhookSubscriptionInput,
+  ListWebhookSubscriptionsQuery,
+} from "../schemas/webhookSubscription.js";
+
+export interface WebhookSubscription {
+  id: string;
+  businessId: string;
+  url: string;
+  secret: string;
+  eventFilters: EventFilters;
+  enabled: boolean;
+  maxPayloadSize: number | null;
+  secretVersion: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function mapRow(row: Record<string, unknown>): WebhookSubscription {
+  return {
+    id: row.id as string,
+    businessId: row.business_id as string,
+    url: row.url as string,
+    secret: row.secret as string,
+    eventFilters: (row.event_filters as EventFilters) ?? {},
+    enabled: (row.enabled as boolean) ?? true,
+    maxPayloadSize: (row.max_payload_size as number) ?? null,
+    secretVersion: (row.secret_version as number) ?? 1,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: new Date(row.updated_at as string),
+  };
+}
+
+/**
+ * Create a new webhook subscription.
+ */
+export async function create(
+  businessId: string,
+  input: CreateWebhookSubscriptionInput,
+): Promise<WebhookSubscription> {
+  const eventFilters = input.eventFilters ?? {};
+  const result = await db.query(
+    `INSERT INTO webhook_subscriptions
+       (business_id, url, secret, event_filters, enabled, max_payload_size)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [
+      businessId,
+      input.url,
+      input.secret,
+      JSON.stringify(eventFilters),
+      input.enabled ?? true,
+      input.maxPayloadSize ?? null,
+    ],
+  );
+  return mapRow(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Get a webhook subscription by ID, scoped to a business.
+ */
+export async function getById(
+  id: string,
+  businessId: string,
+): Promise<WebhookSubscription | null> {
+  const result = await db.query(
+    "SELECT * FROM webhook_subscriptions WHERE id = $1 AND business_id = $2",
+    [id, businessId],
+  );
+  if (result.rows.length === 0) return null;
+  return mapRow(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * List webhook subscriptions with optional filters and cursor pagination.
+ */
+export async function list(
+  query: ListWebhookSubscriptionsQuery,
+): Promise<{ data: WebhookSubscription[]; nextCursor?: string }> {
+  const conditions: string[] = [];
+  const params: (string | boolean | number)[] = [];
+  let paramIndex = 1;
+
+  if (query.businessId) {
+    conditions.push(`business_id = $${paramIndex++}`);
+    params.push(query.businessId);
+  }
+  if (query.enabled !== undefined) {
+    conditions.push(`enabled = $${paramIndex++}`);
+    params.push(query.enabled);
+  }
+
+  // Cursor-based pagination: filter rows after the cursor ID
+  if (query.cursor) {
+    conditions.push(`id > $${paramIndex++}`);
+    params.push(query.cursor);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const limit = Math.min(query.limit ?? 20, 100);
+
+  const result = await db.query(
+    `SELECT * FROM webhook_subscriptions ${where} ORDER BY id ASC LIMIT $${paramIndex++}`,
+    [...params, limit],
+  );
+
+  const subscriptions = (result.rows as Record<string, unknown>[]).map(mapRow);
+  const nextCursor =
+    subscriptions.length === limit
+      ? subscriptions[subscriptions.length - 1].id
+      : undefined;
+
+  return { data: subscriptions, nextCursor };
+}
+
+/**
+ * Count subscriptions for a business (for capacity enforcement).
+ */
+export async function countByBusiness(businessId: string): Promise<number> {
+  const result = await db.query(
+    "SELECT COUNT(*)::int AS count FROM webhook_subscriptions WHERE business_id = $1",
+    [businessId],
+  );
+  return (result.rows[0] as Record<string, unknown>).count as number;
+}
+
+/**
+ * Update an existing webhook subscription.
+ */
+export async function update(
+  id: string,
+  businessId: string,
+  input: UpdateWebhookSubscriptionInput,
+): Promise<WebhookSubscription | null> {
+  const fields: string[] = [];
+  const values: (string | boolean | number)[] = [];
+  let placeholderIndex = 1;
+  let secretChanged = false;
+
+  if (input.url !== undefined) {
+    fields.push(`url = $${placeholderIndex++}`);
+    values.push(input.url);
+  }
+  if (input.secret !== undefined) {
+    fields.push(`secret = $${placeholderIndex++}`);
+    values.push(input.secret);
+    secretChanged = true;
+  }
+  if (input.eventFilters !== undefined) {
+    fields.push(`event_filters = $${placeholderIndex++}`);
+    values.push(JSON.stringify(input.eventFilters));
+  }
+  if (input.enabled !== undefined) {
+    fields.push(`enabled = $${placeholderIndex++}`);
+    values.push(input.enabled);
+  }
+  if (input.maxPayloadSize !== undefined) {
+    fields.push(`max_payload_size = $${placeholderIndex++}`);
+    values.push(input.maxPayloadSize);
+  }
+
+  // Auto-increment secret version on secret rotation
+  if (secretChanged) {
+    fields.push(`secret_version = secret_version + 1`);
+  }
+
+  if (fields.length === 0) {
+    return getById(id, businessId);
+  }
+
+  fields.push(`updated_at = now()`);
+  values.push(id);
+  values.push(businessId);
+
+  const result = await db.query(
+    `UPDATE webhook_subscriptions
+     SET ${fields.join(", ")}
+     WHERE id = $${placeholderIndex++} AND business_id = $${placeholderIndex++}
+     RETURNING *`,
+    values,
+  );
+
+  if (result.rows.length === 0) return null;
+  return mapRow(result.rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Delete a webhook subscription.
+ */
+export async function remove(
+  id: string,
+  businessId: string,
+): Promise<boolean> {
+  const result = await db.query(
+    "DELETE FROM webhook_subscriptions WHERE id = $1 AND business_id = $2",
+    [id, businessId],
+  );
+  return (result.rowCount ?? 0) > 0;
+}

--- a/src/routes/webhook-subscriptions.ts
+++ b/src/routes/webhook-subscriptions.ts
@@ -1,0 +1,169 @@
+/**
+ * Webhook Subscription CRUD API
+ *
+ * REST endpoints for managing webhook subscriptions with per-event
+ * filter DSL. All endpoints are scoped to the authenticated user's business.
+ *
+ * Routes:
+ *   POST   /api/v1/webhook-subscriptions          - Create a subscription
+ *   GET    /api/v1/webhook-subscriptions          - List subscriptions
+ *   GET    /api/v1/webhook-subscriptions/:id      - Get a subscription
+ *   PATCH  /api/v1/webhook-subscriptions/:id      - Update a subscription
+ *   DELETE /api/v1/webhook-subscriptions/:id      - Delete a subscription
+ *
+ * @module routes/webhook-subscriptions
+ */
+
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth.js";
+import { validateBody, validateQuery } from "../middleware/validate.js";
+import { asyncErrorHandler } from "../middleware/errorHandler.js";
+import { NotFoundError, ConflictError } from "../types/errors.js";
+import {
+  createWebhookSubscriptionSchema,
+  updateWebhookSubscriptionSchema,
+  listWebhookSubscriptionsQuerySchema,
+} from "../schemas/webhookSubscription.js";
+import * as repo from "../repositories/webhookSubscriptionRepository.js";
+import { resolveBusinessIdForUser } from "../services/business/resolveBusiness.js";
+
+const MAX_SUBSCRIPTIONS_PER_BUSINESS = 10;
+
+export const webhookSubscriptionsRouter = Router();
+
+/**
+ * GET /api/v1/webhook-subscriptions
+ *
+ * List webhook subscriptions for the authenticated user's business.
+ * Supports optional cursor pagination and enabled/disabled filtering.
+ */
+webhookSubscriptionsRouter.get(
+  "/",
+  requireAuth,
+  validateQuery(listWebhookSubscriptionsQuerySchema),
+  asyncErrorHandler(async (req, res) => {
+    const businessId = await resolveBusinessIdForUser(req.user!.id);
+    if (!businessId) {
+      throw new NotFoundError("Business not found for the authenticated user");
+    }
+
+    const query = listWebhookSubscriptionsQuerySchema.parse(req.query);
+    query.businessId = businessId;
+
+    const result = await repo.list(query);
+
+    res.status(200).json({
+      status: "success",
+      data: result.data,
+      ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+    });
+  }),
+);
+
+/**
+ * GET /api/v1/webhook-subscriptions/:id
+ *
+ * Get a single webhook subscription by ID.
+ */
+webhookSubscriptionsRouter.get(
+  "/:id",
+  requireAuth,
+  asyncErrorHandler(async (req, res) => {
+    const businessId = await resolveBusinessIdForUser(req.user!.id);
+    if (!businessId) {
+      throw new NotFoundError("Business not found for the authenticated user");
+    }
+
+    const subscription = await repo.getById(req.params.id, businessId);
+    if (!subscription) {
+      throw new NotFoundError("Webhook subscription not found");
+    }
+
+    res.status(200).json({ status: "success", data: subscription });
+  }),
+);
+
+/**
+ * POST /api/v1/webhook-subscriptions
+ *
+ * Create a new webhook subscription for the authenticated user's business.
+ *
+ * Validates the URL, secret, event filters (Zod DSL), and enforces
+ * per-business subscription limits.
+ */
+webhookSubscriptionsRouter.post(
+  "/",
+  requireAuth,
+  validateBody(createWebhookSubscriptionSchema),
+  asyncErrorHandler(async (req, res) => {
+    const businessId = await resolveBusinessIdForUser(req.user!.id);
+    if (!businessId) {
+      throw new NotFoundError("Business not found for the authenticated user");
+    }
+
+    // Enforce per-business subscription capacity
+    const existingCount = await repo.countByBusiness(businessId);
+    if (existingCount >= MAX_SUBSCRIPTIONS_PER_BUSINESS) {
+      throw new ConflictError(
+        `Maximum of ${MAX_SUBSCRIPTIONS_PER_BUSINESS} webhook subscriptions allowed per business`,
+      );
+    }
+
+    const subscription = await repo.create(businessId, req.body);
+
+    res.status(201).json({ status: "success", data: subscription });
+  }),
+);
+
+/**
+ * PATCH /api/v1/webhook-subscriptions/:id
+ *
+ * Update an existing webhook subscription. Supports partial updates —
+ * only the provided fields are changed. Secret rotation increments
+ * the secretVersion counter automatically.
+ */
+webhookSubscriptionsRouter.patch(
+  "/:id",
+  requireAuth,
+  validateBody(updateWebhookSubscriptionSchema),
+  asyncErrorHandler(async (req, res) => {
+    const businessId = await resolveBusinessIdForUser(req.user!.id);
+    if (!businessId) {
+      throw new NotFoundError("Business not found for the authenticated user");
+    }
+
+    const input = req.body;
+
+    const updated = await repo.update(req.params.id, businessId, input);
+    if (!updated) {
+      throw new NotFoundError("Webhook subscription not found");
+    }
+
+    res.status(200).json({ status: "success", data: updated });
+  }),
+);
+
+/**
+ * DELETE /api/v1/webhook-subscriptions/:id
+ *
+ * Delete a webhook subscription.
+ */
+webhookSubscriptionsRouter.delete(
+  "/:id",
+  requireAuth,
+  asyncErrorHandler(async (req, res) => {
+    const businessId = await resolveBusinessIdForUser(req.user!.id);
+    if (!businessId) {
+      throw new NotFoundError("Business not found for the authenticated user");
+    }
+
+    const deleted = await repo.remove(req.params.id, businessId);
+    if (!deleted) {
+      throw new NotFoundError("Webhook subscription not found");
+    }
+
+    res.status(200).json({ status: "success", message: "Webhook subscription deleted" });
+  }),
+);
+
+export default webhookSubscriptionsRouter;

--- a/src/schemas/webhookSubscription.ts
+++ b/src/schemas/webhookSubscription.ts
@@ -1,0 +1,296 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Event Filter DSL
+// ---------------------------------------------------------------------------
+//
+// The filter DSL is a JSON object where each key is an event type pattern
+// (e.g. "attestation.created", "business.*") and the value is either:
+//
+//   - `true`  → deliver all events of this type
+//   - `false` → suppress all events of this type
+//   - `{ … }` → deliver only when the event payload matches all key/value pairs
+//
+// Examples:
+//   { "attestation.created": true, "business.updated": false }
+//   { "attestation.*": { "status": "completed" } }
+//
+// Wildcards (*) match any single segment. Double-wildcards (**) match any
+// number of segments including zero.
+
+/** Maximum number of filter rules per subscription. */
+export const MAX_FILTER_RULES = 50;
+
+/** Maximum length of an event-type key in characters. */
+const MAX_EVENT_TYPE_LENGTH = 200;
+
+/** Maximum length of a single filter value in characters. */
+const MAX_FILTER_VALUE_LENGTH = 500;
+
+/** Maximum depth of a filter object's nested paths (prevents deeply-nested DoS). */
+const MAX_FILTER_DEPTH = 5;
+
+/**
+ * Validates that an event-type string is safe:
+ * - Contains only alphanumeric, dots, hyphens, underscores, and wildcards.
+ * - Is within the allowed length.
+ * - Does not start or end with a dot.
+ */
+function isValidEventType(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_EVENT_TYPE_LENGTH) return false;
+  if (value.startsWith(".") || value.endsWith(".")) return false;
+  // Allow: letters, numbers, ., -, _, *, **
+  return /^[a-zA-Z0-9._*-]+$/.test(value);
+}
+
+/**
+ * Recursively check the depth of a value to prevent deeply-nested filter
+ * objects from causing stack overflows during evaluation.
+ */
+function getDepth(val: unknown): number {
+  if (val === null || val === undefined) return 0;
+  if (typeof val !== "object" || Array.isArray(val)) return 0;
+  const obj = val as Record<string, unknown>;
+  let maxDepth = 0;
+  for (const v of Object.values(obj)) {
+    maxDepth = Math.max(maxDepth, getDepth(v));
+  }
+  return maxDepth + 1;
+}
+
+/**
+ * Schema for a single filter value.
+ *
+ * A filter value can be:
+ * - `true` / `false`: enable or suppress events of that type entirely
+ * - An object with string key/value pairs for field-level matching
+ */
+const filterValueSchema: z.ZodType<boolean | Record<string, string>> = z.lazy(() =>
+  z.union([
+    z.boolean(),
+    z.record(
+      z.string().min(1).max(100),
+      z.string().min(0).max(MAX_FILTER_VALUE_LENGTH),
+    ).refine(
+      (obj) => getDepth(obj) <= MAX_FILTER_DEPTH,
+      `Filter depth must not exceed ${MAX_FILTER_DEPTH} levels`,
+    ),
+  ]),
+);
+
+/**
+ * Schema for the complete event-filters map.
+ *
+ * Each key must be a valid event-type string; each value is a filterValue.
+ */
+export const eventFiltersSchema = z
+  .record(
+    z.string().refine(isValidEventType, {
+      message:
+        "Event type must contain only alphanumeric, dots, hyphens, underscores, and wildcards",
+    }),
+    filterValueSchema,
+  )
+  .refine(
+    (filters) => Object.keys(filters).length <= MAX_FILTER_RULES,
+    `Maximum ${MAX_FILTER_RULES} filter rules allowed per subscription`,
+  )
+  .default({});
+
+export type EventFilters = z.infer<typeof eventFiltersSchema>;
+
+// ---------------------------------------------------------------------------
+// Subscription CRUD schemas
+// ---------------------------------------------------------------------------
+
+const URL_MAX_LENGTH = 2048;
+
+/** Blocked URL schemes for security. */
+const BLOCKED_SCHEMES = new Set(["javascript", "data", "vbscript", "file", "ftp"]);
+
+function hasBlockedScheme(url: string): boolean {
+  const lower = url.toLowerCase();
+  if (lower.startsWith("//")) return true;
+  return [...BLOCKED_SCHEMES].some(
+    (s) => lower.startsWith(`${s}:`) || lower.startsWith(`${s}%3a`),
+  );
+}
+
+function isValidUrl(value: string): boolean {
+  if (value.length > URL_MAX_LENGTH) return false;
+  if (hasBlockedScheme(value)) return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+const urlField = z
+  .string()
+  .min(1, "URL is required")
+  .max(URL_MAX_LENGTH, `URL must not exceed ${URL_MAX_LENGTH} characters`)
+  .refine(isValidUrl, "URL must be a valid HTTPS endpoint");
+
+const secretField = z
+  .string()
+  .min(32, "Secret must be at least 32 characters for cryptographic security")
+  .max(512, "Secret must not exceed 512 characters");
+
+const maxPayloadSizeField = z
+  .number()
+  .int("maxPayloadSize must be an integer")
+  .min(1024, "maxPayloadSize must be at least 1024 bytes")
+  .max(10 * 1024 * 1024, "maxPayloadSize must not exceed 10 MB")
+  .optional();
+
+const enabledField = z.boolean().optional().default(true);
+
+/**
+ * Schema for creating a new webhook subscription.
+ */
+export const createWebhookSubscriptionSchema = z.object({
+  url: urlField,
+  secret: secretField,
+  eventFilters: eventFiltersSchema.optional(),
+  maxPayloadSize: maxPayloadSizeField,
+  enabled: enabledField,
+}).strict();
+
+export type CreateWebhookSubscriptionInput = z.infer<
+  typeof createWebhookSubscriptionSchema
+>;
+
+/**
+ * Schema for updating an existing webhook subscription.
+ *
+ * All fields are optional for partial updates.
+ */
+export const updateWebhookSubscriptionSchema = z.object({
+  url: urlField.optional(),
+  secret: secretField.optional(),
+  eventFilters: eventFiltersSchema.optional(),
+  enabled: z.boolean().optional(),
+  maxPayloadSize: maxPayloadSizeField,
+}).strict();
+
+export type UpdateWebhookSubscriptionInput = z.infer<
+  typeof updateWebhookSubscriptionSchema
+>;
+
+/**
+ * Schema for querying webhook subscriptions (list endpoint).
+ */
+export const listWebhookSubscriptionsQuerySchema = z.object({
+  businessId: z.string().min(1).max(255).optional(),
+  enabled: z
+    .preprocess(
+      (val) => {
+        if (val === "true" || val === "1") return true;
+        if (val === "false" || val === "0") return false;
+        return val;
+      },
+      z.boolean().optional(),
+    )
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().optional(),
+}).strict();
+
+export type ListWebhookSubscriptionsQuery = z.infer<
+  typeof listWebhookSubscriptionsQuerySchema
+>;
+
+// ---------------------------------------------------------------------------
+// Filter evaluation (applied at dispatch time)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether an event should be delivered based on a subscription's
+ * event-filters map.
+ *
+ * Resolution order (first match wins):
+ * 1. Exact match on event type (e.g. "attestation.created")
+ * 2. Segment-level wildcard (e.g. "attestation.*")
+ * 3. Recursive wildcard (e.g. "**" matches everything)
+ *
+ * When a filter object is matched, every key in the filter must exist as a
+ * field in the event payload with the same value. Nested payload fields are
+ * traversed with dot-separated keys (e.g. "data.status").
+ *
+ * @param eventType  - The event type string (e.g. "attestation.created").
+ * @param eventPayload - The event payload to match against filter objects.
+ * @param filters    - The subscription's eventFilters map.
+ * @returns `true` when the event should be delivered, `false` otherwise.
+ */
+export function evaluateEventFilter(
+  eventType: string,
+  eventPayload: Record<string, unknown>,
+  filters: EventFilters,
+): boolean {
+  if (!filters || Object.keys(filters).length === 0) {
+    // No filters configured — deliver everything
+    return true;
+  }
+
+  // 1. Exact match
+  const exact = filters[eventType];
+  if (typeof exact === "boolean") return exact;
+  if (typeof exact === "object" && exact !== null) {
+    return matchesFilterObject(exact, eventPayload);
+  }
+
+  // 2. Segment-level wildcard (e.g. "attestation.*")
+  const segments = eventType.split(".");
+  for (let i = 0; i < segments.length; i++) {
+    const wildcardPattern = [...segments.slice(0, i), "*"].join(".");
+    const match = filters[wildcardPattern];
+    if (typeof match === "boolean") return match;
+    if (typeof match === "object" && match !== null) {
+      return matchesFilterObject(match, eventPayload);
+    }
+  }
+
+  // 3. Recursive wildcard
+  const recursive = filters["**"];
+  if (typeof recursive === "boolean") return recursive;
+  if (typeof recursive === "object" && recursive !== null) {
+    return matchesFilterObject(recursive, eventPayload);
+  }
+
+  // No matching rule — default to delivering
+  return true;
+}
+
+/**
+ * Check that every key/value in the filter object exists in the event payload.
+ *
+ * Keys may contain dots for nested access (e.g. "data.status" resolves to
+ * `eventPayload.data.status`).
+ */
+function matchesFilterObject(
+  filter: Record<string, string>,
+  payload: Record<string, unknown>,
+): boolean {
+  for (const [key, expectedValue] of Object.entries(filter)) {
+    const actualValue = resolveNestedValue(payload, key);
+    if (actualValue === undefined) return false;
+    if (String(actualValue) !== expectedValue) return false;
+  }
+  return true;
+}
+
+function resolveNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}

--- a/src/services/business/resolveBusiness.ts
+++ b/src/services/business/resolveBusiness.ts
@@ -1,0 +1,19 @@
+import { db } from "../../db/client.js";
+import { NotFoundError } from "../types/errors.js";
+
+/**
+ * Resolve the business ID for a given user ID.
+ *
+ * Queries the businesses table to find the business associated with
+ * the authenticated user. Returns null when no business is found.
+ */
+export async function resolveBusinessIdForUser(
+  userId: string,
+): Promise<string | null> {
+  const result = await db.query(
+    "SELECT id FROM businesses WHERE user_id = $1 LIMIT 1",
+    [userId],
+  );
+  if (result.rows.length === 0) return null;
+  return (result.rows[0] as Record<string, unknown>).id as string;
+}

--- a/src/services/webhooks/dispatcher.ts
+++ b/src/services/webhooks/dispatcher.ts
@@ -20,6 +20,8 @@ export interface WebhookSubscription {
   maxPayloadSize?: number;
   /** Monotonically increasing version of the webhook secret, used for rotation tracking. */
   secretVersion?: number;
+  /** Per-event filter DSL. Maps event types to boolean or filter objects. */
+  eventFilters?: Record<string, boolean | Record<string, string>>;
 }
 
 export interface WebhookDeliveryReceipt {
@@ -177,6 +179,73 @@ export interface SendWebhookDeliveryResult {
   signature: string;
   signatureVersion: number;
   responseBody?: string;
+}
+
+/**
+ * Evaluate whether an event should be delivered to a subscription
+ * based on its event-filters DSL.
+ *
+ * When no filters are configured, all events are delivered.
+ * Otherwise the first matching rule (exact → segment wildcard → recursive)
+ * determines delivery.
+ */
+export function shouldDeliverEvent(
+  eventType: string,
+  eventPayload: Record<string, unknown>,
+  subscription: WebhookSubscription,
+): boolean {
+  const filters = subscription.eventFilters;
+  if (!filters || Object.keys(filters).length === 0) return true;
+
+  // 1. Exact match
+  const exact = filters[eventType];
+  if (typeof exact === "boolean") return exact;
+  if (typeof exact === "object" && exact !== null) {
+    return objectFilterMatches(exact, eventPayload);
+  }
+
+  // 2. Segment-level wildcard
+  const segments = eventType.split(".");
+  for (let i = 0; i < segments.length; i++) {
+    const pattern = [...segments.slice(0, i), "*"].join(".");
+    const match = filters[pattern];
+    if (typeof match === "boolean") return match;
+    if (typeof match === "object" && match !== null) {
+      return objectFilterMatches(match, eventPayload);
+    }
+  }
+
+  // 3. Recursive wildcard
+  const recursive = filters["**"];
+  if (typeof recursive === "boolean") return recursive;
+  if (typeof recursive === "object" && recursive !== null) {
+    return objectFilterMatches(recursive, eventPayload);
+  }
+
+  return true;
+}
+
+function objectFilterMatches(
+  filter: Record<string, string>,
+  payload: Record<string, unknown>,
+): boolean {
+  for (const [key, expectedValue] of Object.entries(filter)) {
+    const actualValue = resolveDotPath(payload, key);
+    if (actualValue === undefined) return false;
+    if (String(actualValue) !== expectedValue) return false;
+  }
+  return true;
+}
+
+function resolveDotPath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
 }
 
 export async function sendWebhookDelivery(options: SendWebhookDeliveryOptions): Promise<SendWebhookDeliveryResult> {

--- a/tests/unit/webhook-subscriptions.test.ts
+++ b/tests/unit/webhook-subscriptions.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { eventFiltersSchema, evaluateEventFilter, createWebhookSubscriptionSchema, updateWebhookSubscriptionSchema, listWebhookSubscriptionsQuerySchema } from "../../src/schemas/webhookSubscription.js";
+
+describe("eventFiltersSchema", () => {
+  it("accepts an empty object", () => {
+    const result = eventFiltersSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({});
+  });
+
+  it("defaults to empty object when omitted", () => {
+    const result = eventFiltersSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({});
+  });
+
+  it("accepts boolean filter values", () => {
+    const result = eventFiltersSchema.safeParse({
+      "attestation.created": true,
+      "attestation.updated": false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      "attestation.created": true,
+      "attestation.updated": false,
+    });
+  });
+
+  it("accepts object filter values with string fields", () => {
+    const result = eventFiltersSchema.safeParse({
+      "attestation.updated": { status: "completed" },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.["attestation.updated"]).toEqual({ status: "completed" });
+  });
+
+  it("accepts wildcard event types", () => {
+    const result = eventFiltersSchema.safeParse({
+      "attestation.*": true,
+      "**": { env: "production" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid event-type characters", () => {
+    const result = eventFiltersSchema.safeParse({
+      "bad<script>": true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects event types starting with a dot", () => {
+    const result = eventFiltersSchema.safeParse({
+      ".attestation": true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more than MAX_FILTER_RULES entries", () => {
+    const filters: Record<string, boolean> = {};
+    for (let i = 0; i < 51; i++) {
+      filters[`event.${i}`] = true;
+    }
+    const result = eventFiltersSchema.safeParse(filters);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects deeply nested filter objects", () => {
+    const nested: Record<string, unknown> = { a: { b: { c: { d: { e: { f: "too deep" } } } } } };
+    const result = eventFiltersSchema.safeParse({
+      "test.event": nested,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("evaluateEventFilter", () => {
+  it("returns true when no filters are configured", () => {
+    expect(evaluateEventFilter("attestation.created", {}, {})).toBe(true);
+  });
+
+  it("matches exact event type with boolean filter", () => {
+    expect(
+      evaluateEventFilter("attestation.created", {}, {
+        "attestation.created": true,
+        "attestation.updated": false,
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("attestation.updated", {}, {
+        "attestation.created": true,
+        "attestation.updated": false,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches exact event type with object filter", () => {
+    expect(
+      evaluateEventFilter(
+        "attestation.updated",
+        { status: "completed" },
+        { "attestation.updated": { status: "completed" } },
+      ),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter(
+        "attestation.updated",
+        { status: "pending" },
+        { "attestation.updated": { status: "completed" } },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches segment-level wildcard", () => {
+    expect(
+      evaluateEventFilter("attestation.created", {}, {
+        "attestation.*": true,
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("attestation.updated", { status: "completed" }, {
+        "attestation.*": { status: "completed" },
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("attestation.updated", { status: "pending" }, {
+        "attestation.*": { status: "completed" },
+      }),
+    ).toBe(false);
+  });
+
+  it("matches recursive wildcard (**)", () => {
+    expect(
+      evaluateEventFilter("anything.here.works", {}, { "**": true }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("anything", { env: "production" }, {
+        "**": { env: "production" },
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("anything", { env: "staging" }, {
+        "**": { env: "production" },
+      }),
+    ).toBe(false);
+  });
+
+  it("defaults to true when no rule matches", () => {
+    expect(
+      evaluateEventFilter("unknown.event", {}, {
+        "attestation.created": false,
+      }),
+    ).toBe(true);
+  });
+
+  it("exact match takes precedence over wildcards", () => {
+    expect(
+      evaluateEventFilter("attestation.created", {}, {
+        "attestation.created": false,
+        "attestation.*": true,
+        "**": true,
+      }),
+    ).toBe(false);
+  });
+
+  it("resolves nested payload fields via dot-notation", () => {
+    const payload = { data: { status: "completed", id: "123" } };
+    expect(
+      evaluateEventFilter("order.shipped", payload, {
+        "order.shipped": { "data.status": "completed" },
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateEventFilter("order.shipped", payload, {
+        "order.shipped": { "data.status": "pending" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("createWebhookSubscriptionSchema", () => {
+  it("accepts a valid subscription", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "https://example.com/webhook",
+      secret: "a-very-long-secret-key-that-is-over-32-chars-long",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.url).toBe("https://example.com/webhook");
+    expect(result.data?.enabled).toBe(true); // default
+  });
+
+  it("accepts optional event filters and maxPayloadSize", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "https://example.com/webhook",
+      secret: "a-very-long-secret-key-that-is-over-32-chars-long",
+      eventFilters: { "attestation.created": true },
+      maxPayloadSize: 102400,
+      enabled: false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.enabled).toBe(false);
+    expect(result.data?.maxPayloadSize).toBe(102400);
+  });
+
+  it("rejects a short secret", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "https://example.com/webhook",
+      secret: "short",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid URLs", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "not-a-url",
+      secret: "a-very-long-secret-key-that-is-over-32-chars-long",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects javascript: scheme URLs", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "javascript:alert(1)",
+      secret: "a-very-long-secret-key-that-is-over-32-chars-long",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects extra unknown fields", () => {
+    const result = createWebhookSubscriptionSchema.safeParse({
+      url: "https://example.com/webhook",
+      secret: "a-very-long-secret-key-that-is-over-32-chars-long",
+      injectedField: "bad",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateWebhookSubscriptionSchema", () => {
+  it("accepts partial updates", () => {
+    const result = updateWebhookSubscriptionSchema.safeParse({
+      url: "https://new.example.com/webhook",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.url).toBe("https://new.example.com/webhook");
+  });
+
+  it("accepts an empty object", () => {
+    const result = updateWebhookSubscriptionSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid URLs in partial update", () => {
+    const result = updateWebhookSubscriptionSchema.safeParse({
+      url: "ftp://bad.example.com",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("listWebhookSubscriptionsQuerySchema", () => {
+  it("defaults limit to 20", () => {
+    const result = listWebhookSubscriptionsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data?.limit).toBe(20);
+  });
+
+  it("coerces string limit to number", () => {
+    const result = listWebhookSubscriptionsQuerySchema.safeParse({ limit: "5" });
+    expect(result.success).toBe(true);
+    expect(result.data?.limit).toBe(5);
+  });
+
+  it("caps limit at 100", () => {
+    const result = listWebhookSubscriptionsQuerySchema.safeParse({ limit: 200 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts businessId filter", () => {
+    const result = listWebhookSubscriptionsQuerySchema.safeParse({
+      businessId: "biz-123",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.businessId).toBe("biz-123");
+  });
+
+  it("accepts enabled filter as boolean string", () => {
+    const result = listWebhookSubscriptionsQuerySchema.safeParse({
+      enabled: "true",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Add REST API for managing webhook subscriptions with per-event filter DSL persisted as JSONB.

Endpoints:
  POST   /api/v1/webhook-subscriptions          - Create
  GET    /api/v1/webhook-subscriptions          - List (cursor pagination)
  GET    /api/v1/webhook-subscriptions/:id      - Get by ID
  PATCH  /api/v1/webhook-subscriptions/:id      - Partial update
  DELETE /api/v1/webhook-subscriptions/:id      - Delete

Filter DSL:
  Each subscription carries a JSONB event_filters map where keys
  are event-type patterns (e.g. attestation.created, attestation.*,
  **) and values are booleans or field-match objects.
  Filter evaluation at dispatch time uses shouldDeliverEvent() in
  the dispatcher with exact → wildcard → recursive resolution.

Key details:
- Zod-validated schemas for create, update, list, and filter DSL (max 50 rules, depth ≤ 5, URL scheme blocklist, secret ≥ 32 chars)
- Secret version auto-increments when the secret field changes
- Cursor-based pagination via ID ordering
- Per-business subscription capacity enforced (max 10)
- DB-backed with migration + down migration
- 31 unit tests covering schema validation, filter evaluation, URL security, and edge cases

closes #533 