### PR TITLE
feat: generate third-party notice bundle

### DIFF
--- a/.github/workflows/notices-check.yml
+++ b/.github/workflows/notices-check.yml
@@ -1,0 +1,33 @@
+name: notices-check
+
+on:
+  push:
+    paths:
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "docs/legal/NOTICES.md"
+      - "scripts/generate-notices.ts"
+  pull_request:
+    paths:
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "docs/legal/NOTICES.md"
+      - "scripts/generate-notices.ts"
+
+jobs:
+  notices-staleness:
+    name: Check NOTICES bundle is up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Check NOTICES bundle staleness
+        run: npx tsx scripts/generate-notices.ts --check --output docs/legal/NOTICES.md

--- a/docs/legal/NOTICES.md
+++ b/docs/legal/NOTICES.md
@@ -1,0 +1,11 @@
+# Third-Party Notices
+
+This file is auto-generated. Do not edit manually.
+Generated: <run `npm run notices:generate` to populate>
+
+This product includes software developed by third parties.
+The following packages are used under the terms of their respective licenses.
+
+---
+
+*Run `npm run notices:generate` to regenerate this file from the current lockfile.*

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "rebuild:indexer": "tsx scripts/rebuild-indexer.ts",
     "pact:can-i-deploy": "tsx scripts/can-i-deploy.ts",
     "pact:test": "vitest run tests/pact/",
-    "pact:publish": "tsx scripts/publish-pact.ts"
+    "pact:publish": "tsx scripts/publish-pact.ts",
+    "notices:generate": "tsx scripts/generate-notices.ts --output docs/legal/NOTICES.md",
+    "notices:check": "tsx scripts/generate-notices.ts --check --output docs/legal/NOTICES.md"
   },
   "dependencies": {
     "@google-cloud/secret-manager": "^5.6.0",

--- a/scripts/generate-notices.ts
+++ b/scripts/generate-notices.ts
@@ -1,0 +1,216 @@
+/**
+ * Generate an aggregated third-party NOTICES bundle from installed npm packages.
+ *
+ * Usage:
+ *   tsx scripts/generate-notices.ts [--output <path>] [--check]
+ *
+ * --output  Path to write the bundle (default: docs/legal/NOTICES.md)
+ * --check   Exit 1 if the on-disk file differs from the freshly generated content
+ *           (used in CI to detect stale bundles).
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_OUTPUT = "docs/legal/NOTICES.md";
+
+export interface PackageNotice {
+  name: string;
+  version: string;
+  license: string;
+  licenseText: string | null;
+  repository: string | null;
+}
+
+export interface GenerateNoticesOptions {
+  output: string;
+  check?: boolean;
+  cwd?: string;
+}
+
+export interface CliArgs {
+  output: string;
+  check: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  let output = DEFAULT_OUTPUT;
+  let check = false;
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--output": {
+        const val = argv[++i];
+        if (!val || val.startsWith("--")) throw new Error("--output requires a file path");
+        output = val;
+        break;
+      }
+      case "--check":
+        check = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${argv[i]}`);
+    }
+  }
+  return { output, check };
+}
+
+export async function runChecker(startPath: string): Promise<Record<string, any>> {
+  // Dynamic import keeps license-checker (CJS) out of the module graph at load
+  // time, so tests that don't exercise this path can import the module cleanly.
+  const checker = (await import("license-checker")).default;
+  return new Promise((res, rej) => {
+    checker.init(
+      { start: startPath, production: true, excludePrivatePackages: true },
+      (err: Error | null, packages: Record<string, any>) =>
+        err ? rej(err) : res(packages),
+    );
+  });
+}
+
+export async function readLicenseText(licenseFile: string | undefined): Promise<string | null> {
+  if (!licenseFile || !existsSync(licenseFile)) return null;
+  try {
+    return await readFile(licenseFile, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function normalizePackages(raw: Record<string, any>): PackageNotice[] {
+  const notices: PackageNotice[] = [];
+  for (const [nameVersion, info] of Object.entries(raw)) {
+    const atIdx = nameVersion.lastIndexOf("@");
+    const name = atIdx > 0 ? nameVersion.slice(0, atIdx) : nameVersion;
+    const version = atIdx > 0 ? nameVersion.slice(atIdx + 1) : "unknown";
+    const license =
+      typeof info.licenses === "string"
+        ? info.licenses
+        : Array.isArray(info.licenses)
+          ? (info.licenses as string[]).join(", ")
+          : "UNKNOWN";
+    notices.push({
+      name,
+      version,
+      license,
+      licenseText: null,
+      repository: typeof info.repository === "string" ? info.repository : null,
+    });
+  }
+  return notices.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function collectNotices(raw: Record<string, any>): Promise<PackageNotice[]> {
+  const base = normalizePackages(raw);
+  return Promise.all(
+    base.map(async (pkg) => {
+      const key = Object.keys(raw).find((k) => {
+        const atIdx = k.lastIndexOf("@");
+        return (
+          (atIdx > 0 ? k.slice(0, atIdx) : k) === pkg.name &&
+          (atIdx > 0 ? k.slice(atIdx + 1) : "unknown") === pkg.version
+        );
+      });
+      const licenseFile = key ? raw[key]?.licenseFile : undefined;
+      return { ...pkg, licenseText: await readLicenseText(licenseFile) };
+    }),
+  );
+}
+
+export function renderNotices(notices: PackageNotice[], generatedAt: string): string {
+  const lines: string[] = [
+    "# Third-Party Notices",
+    "",
+    "This file is auto-generated. Do not edit manually.",
+    `Generated: ${generatedAt}`,
+    "",
+    "This product includes software developed by third parties.",
+    "The following packages are used under the terms of their respective licenses.",
+    "",
+    "---",
+    "",
+  ];
+
+  for (const pkg of notices) {
+    lines.push(`## ${pkg.name} @ ${pkg.version}`);
+    lines.push("");
+    lines.push(`License: ${pkg.license}`);
+    if (pkg.repository) lines.push(`Repository: ${pkg.repository}`);
+    lines.push("");
+    if (pkg.licenseText) {
+      lines.push("```");
+      lines.push(pkg.licenseText.trim());
+      lines.push("```");
+    } else {
+      lines.push("*License text not available. See package repository for details.*");
+    }
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+export async function generateNotices(
+  options: GenerateNoticesOptions,
+  _runChecker = runChecker,
+): Promise<{ output: string; content: string; stale?: boolean }> {
+  const cwd = options.cwd ?? process.cwd();
+  const outputPath = resolve(cwd, options.output);
+
+  const raw = await _runChecker(cwd);
+  const notices = await collectNotices(raw);
+  const content = renderNotices(notices, new Date().toISOString());
+
+  if (options.check) {
+    let existing: string | null = null;
+    try {
+      existing = await readFile(outputPath, "utf8");
+    } catch {
+      // file missing → stale
+    }
+    const strip = (s: string) => s.replace(/^Generated: .+$/m, "Generated: <timestamp>");
+    const stale = existing === null || strip(existing) !== strip(content);
+    return { output: outputPath, content, stale };
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, content, "utf8");
+  return { output: outputPath, content };
+}
+
+async function main(): Promise<void> {
+  const args = parseCliArgs(process.argv.slice(2));
+  const result = await generateNotices({ output: args.output, check: args.check });
+
+  if (args.check) {
+    if (result.stale) {
+      console.error(
+        `NOTICES bundle is stale. Run \`npm run notices:generate\` and commit the result.\n` +
+          `Expected file: ${result.output}`,
+      );
+      process.exitCode = 1;
+    } else {
+      console.log("NOTICES bundle is up-to-date.");
+    }
+    return;
+  }
+
+  console.log(`NOTICES bundle written to ${result.output}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err: unknown) => {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/scripts/generate-notices.test.ts
+++ b/tests/scripts/generate-notices.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseCliArgs,
+  normalizePackages,
+  renderNotices,
+  generateNotices,
+  type PackageNotice,
+} from "../../scripts/generate-notices";
+
+// ---------------------------------------------------------------------------
+// parseCliArgs
+// ---------------------------------------------------------------------------
+describe("parseCliArgs", () => {
+  it("returns defaults when no args given", () => {
+    expect(parseCliArgs([])).toEqual({ output: "docs/legal/NOTICES.md", check: false });
+  });
+
+  it("parses --output", () => {
+    expect(parseCliArgs(["--output", "out/NOTICES.md"])).toMatchObject({ output: "out/NOTICES.md" });
+  });
+
+  it("parses --check", () => {
+    expect(parseCliArgs(["--check"])).toMatchObject({ check: true });
+  });
+
+  it("parses --output and --check together", () => {
+    expect(parseCliArgs(["--output", "x.md", "--check"])).toEqual({ output: "x.md", check: true });
+  });
+
+  it("throws on --output without value", () => {
+    expect(() => parseCliArgs(["--output"])).toThrow("--output requires a file path");
+  });
+
+  it("throws on --output followed by another flag", () => {
+    expect(() => parseCliArgs(["--output", "--check"])).toThrow("--output requires a file path");
+  });
+
+  it("throws on unknown argument", () => {
+    expect(() => parseCliArgs(["--unknown"])).toThrow("Unknown argument: --unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizePackages
+// ---------------------------------------------------------------------------
+describe("normalizePackages", () => {
+  it("splits name and version correctly", () => {
+    const result = normalizePackages({ "express@4.18.0": { licenses: "MIT" } as any });
+    expect(result[0]).toMatchObject({ name: "express", version: "4.18.0", license: "MIT" });
+  });
+
+  it("handles scoped packages (@scope/pkg@version)", () => {
+    const result = normalizePackages({ "@scope/pkg@1.0.0": { licenses: "Apache-2.0" } as any });
+    expect(result[0]).toMatchObject({ name: "@scope/pkg", version: "1.0.0", license: "Apache-2.0" });
+  });
+
+  it("joins array licenses with comma", () => {
+    const result = normalizePackages({ "dual@1.0.0": { licenses: ["MIT", "BSD-2-Clause"] } as any });
+    expect(result[0].license).toBe("MIT, BSD-2-Clause");
+  });
+
+  it("falls back to UNKNOWN when licenses is missing", () => {
+    const result = normalizePackages({ "nolic@1.0.0": {} as any });
+    expect(result[0].license).toBe("UNKNOWN");
+  });
+
+  it("extracts repository string", () => {
+    const result = normalizePackages({
+      "pkg@1.0.0": { licenses: "MIT", repository: "https://github.com/org/pkg" } as any,
+    });
+    expect(result[0].repository).toBe("https://github.com/org/pkg");
+  });
+
+  it("sets repository to null when not a string", () => {
+    const result = normalizePackages({ "pkg@1.0.0": { licenses: "MIT", repository: { url: "x" } } as any });
+    expect(result[0].repository).toBeNull();
+  });
+
+  it("sorts packages alphabetically by name", () => {
+    const result = normalizePackages({
+      "zlib@1.0.0": { licenses: "MIT" } as any,
+      "alib@1.0.0": { licenses: "MIT" } as any,
+    });
+    expect(result[0].name).toBe("alib");
+    expect(result[1].name).toBe("zlib");
+  });
+
+  it("handles empty input", () => {
+    expect(normalizePackages({})).toEqual([]);
+  });
+
+  it("sets licenseText to null (filled later by collectNotices)", () => {
+    const result = normalizePackages({ "pkg@1.0.0": { licenses: "MIT" } as any });
+    expect(result[0].licenseText).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderNotices
+// ---------------------------------------------------------------------------
+describe("renderNotices", () => {
+  const ts = "2025-01-01T00:00:00.000Z";
+
+  it("includes the header and timestamp", () => {
+    const out = renderNotices([], ts);
+    expect(out).toContain("# Third-Party Notices");
+    expect(out).toContain(`Generated: ${ts}`);
+    expect(out).toContain("auto-generated");
+  });
+
+  it("renders a package entry with license text", () => {
+    const notices: PackageNotice[] = [
+      {
+        name: "express",
+        version: "4.18.0",
+        license: "MIT",
+        licenseText: "MIT License\n...",
+        repository: "https://github.com/expressjs/express",
+      },
+    ];
+    const out = renderNotices(notices, ts);
+    expect(out).toContain("## express @ 4.18.0");
+    expect(out).toContain("License: MIT");
+    expect(out).toContain("Repository: https://github.com/expressjs/express");
+    expect(out).toContain("MIT License");
+    expect(out).toContain("```");
+  });
+
+  it("renders fallback text when licenseText is null", () => {
+    const notices: PackageNotice[] = [
+      { name: "pkg", version: "1.0.0", license: "ISC", licenseText: null, repository: null },
+    ];
+    const out = renderNotices(notices, ts);
+    expect(out).toContain("*License text not available");
+    expect(out).not.toContain("Repository:");
+  });
+
+  it("omits repository line when repository is null", () => {
+    const notices: PackageNotice[] = [
+      { name: "pkg", version: "1.0.0", license: "MIT", licenseText: "text", repository: null },
+    ];
+    const out = renderNotices(notices, ts);
+    expect(out).not.toContain("Repository:");
+  });
+
+  it("renders multiple packages separated by ---", () => {
+    const notices: PackageNotice[] = [
+      { name: "a", version: "1.0.0", license: "MIT", licenseText: null, repository: null },
+      { name: "b", version: "2.0.0", license: "Apache-2.0", licenseText: null, repository: null },
+    ];
+    const out = renderNotices(notices, ts);
+    expect(out).toContain("## a @ 1.0.0");
+    expect(out).toContain("## b @ 2.0.0");
+    expect((out.match(/^---$/gm) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders empty package list without package entries", () => {
+    const out = renderNotices([], ts);
+    expect(out).toContain("# Third-Party Notices");
+    expect(out).not.toContain("##");
+  });
+
+  it("trims license text before rendering", () => {
+    const notices: PackageNotice[] = [
+      { name: "pkg", version: "1.0.0", license: "MIT", licenseText: "  MIT text  \n", repository: null },
+    ];
+    const out = renderNotices(notices, ts);
+    expect(out).toContain("MIT text");
+    // Should not have leading/trailing whitespace inside the code block
+    expect(out).not.toMatch(/```\n\s+MIT text/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateNotices (integration-style with mocked checker, real FS via tmpdir)
+// ---------------------------------------------------------------------------
+describe("generateNotices", () => {
+  const makeChecker = (packages: Record<string, any>) =>
+    vi.fn().mockResolvedValue(packages);
+
+  it("writes NOTICES.md to the specified output path", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({ "express@4.18.0": { licenses: "MIT" } });
+    const result = await generateNotices({ output: "docs/legal/NOTICES.md", cwd }, checker);
+    expect(result.output).toContain("NOTICES.md");
+    expect(result.content).toContain("## express @ 4.18.0");
+    const written = await readFile(result.output, "utf8");
+    expect(written).toBe(result.content);
+  });
+
+  it("creates parent directories if they do not exist", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({});
+    const result = await generateNotices({ output: "deep/nested/NOTICES.md", cwd }, checker);
+    const written = await readFile(result.output, "utf8");
+    expect(written).toContain("# Third-Party Notices");
+  });
+
+  it("returns stale=true in check mode when file is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({ "pkg@1.0.0": { licenses: "MIT" } });
+    const result = await generateNotices({ output: "docs/legal/NOTICES.md", check: true, cwd }, checker);
+    expect(result.stale).toBe(true);
+  });
+
+  it("returns stale=false in check mode when content matches (ignoring timestamp)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const packages = { "pkg@1.0.0": { licenses: "MIT" } };
+
+    // Write first
+    await generateNotices({ output: "docs/legal/NOTICES.md", cwd }, makeChecker(packages));
+
+    // Check — should be up-to-date
+    const result = await generateNotices(
+      { output: "docs/legal/NOTICES.md", check: true, cwd },
+      makeChecker(packages),
+    );
+    expect(result.stale).toBe(false);
+  });
+
+  it("returns stale=true in check mode when packages changed", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+
+    await generateNotices(
+      { output: "docs/legal/NOTICES.md", cwd },
+      makeChecker({ "pkg@1.0.0": { licenses: "MIT" } }),
+    );
+
+    const result = await generateNotices(
+      { output: "docs/legal/NOTICES.md", check: true, cwd },
+      makeChecker({ "other@2.0.0": { licenses: "Apache-2.0" } }),
+    );
+    expect(result.stale).toBe(true);
+  });
+
+  it("includes license text when licenseFile exists on disk", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const licenseFile = join(cwd, "LICENSE");
+    await writeFile(licenseFile, "MIT License text here");
+
+    const checker = makeChecker({ "pkg@1.0.0": { licenses: "MIT", licenseFile } });
+    const result = await generateNotices({ output: "NOTICES.md", cwd }, checker);
+    expect(result.content).toContain("MIT License text here");
+  });
+
+  it("handles packages with no license gracefully", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({ "nolic@1.0.0": {} });
+    const result = await generateNotices({ output: "NOTICES.md", cwd }, checker);
+    expect(result.content).toContain("UNKNOWN");
+    expect(result.content).toContain("*License text not available");
+  });
+
+  it("handles empty package list", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({});
+    const result = await generateNotices({ output: "NOTICES.md", cwd }, checker);
+    expect(result.content).toContain("# Third-Party Notices");
+    expect(result.content).not.toContain("##");
+  });
+
+  it("propagates checker errors", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = vi.fn().mockRejectedValue(new Error("checker failed"));
+    await expect(generateNotices({ output: "NOTICES.md", cwd }, checker)).rejects.toThrow("checker failed");
+  });
+
+  it("handles missing licenseFile path gracefully (null text)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    // licenseFile points to a non-existent path
+    const checker = makeChecker({
+      "pkg@1.0.0": { licenses: "MIT", licenseFile: join(cwd, "nonexistent-LICENSE") },
+    });
+    const result = await generateNotices({ output: "NOTICES.md", cwd }, checker);
+    expect(result.content).toContain("*License text not available");
+  });
+
+  it("does not write file in check mode", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({ "pkg@1.0.0": { licenses: "MIT" } });
+    await generateNotices({ output: "NOTICES.md", check: true, cwd }, checker);
+    // File should not exist since we only checked
+    await expect(readFile(join(cwd, "NOTICES.md"), "utf8")).rejects.toThrow();
+  });
+
+  it("sorts packages alphabetically in output", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "notices-test-"));
+    const checker = makeChecker({
+      "zpackage@1.0.0": { licenses: "MIT" },
+      "apackage@1.0.0": { licenses: "MIT" },
+    });
+    const result = await generateNotices({ output: "NOTICES.md", cwd }, checker);
+    const aIdx = result.content.indexOf("## apackage");
+    const zIdx = result.content.indexOf("## zpackage");
+    expect(aIdx).toBeLessThan(zIdx);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ export default {
   test: {
     globals: true,
     environment: 'node',
+    pool: 'vmForks',
     include: ['tests/**/*.test.ts', 'tests/**/*.spec.ts', 'src/**/*.test.ts', 'src/**/*.spec.ts'],
     env: {
       DATABASE_URL: "postgres://localhost:5432/test_db",
@@ -17,11 +18,6 @@ export default {
       include: ["src/**/*.ts", "src/**/*.js"],
       exclude: ["src/**/*.d.ts", "src/index.ts"],
       reportsDirectory: "coverage",
-    },
-    server: {
-      deps: {
-        inline: ["C:"],
-      },
     },
   },
 };


### PR DESCRIPTION
## feat: generate third-party notice bundle

Closes #567

---

### Summary

Adds an automated third-party notice bundle to the repository. A new
script aggregates license metadata and license text from every
production npm dependency and writes a structured Markdown file to
`docs/legal/NOTICES.md`. A CI workflow detects stale bundles whenever
the lockfile or the script itself changes, blocking merges until the
bundle is regenerated and committed.

---

### Changes

| File | Type | Description |
|---|---|---|
| `scripts/generate-notices.ts` | New | Core generation script |
| `docs/legal/NOTICES.md` | New | Output bundle (placeholder; regenerated by script) |
| `.github/workflows/notices-check.yml` | New | CI staleness gate |
| `tests/scripts/generate-notices.test.ts` | New | 35 unit tests |
| `package.json` | Modified | Added `notices:generate` and `notices:check` scripts |
| `vitest.config.ts` | Modified | Fixed pre-existing ESM crash on Node 24 / Vite 8 |

---

### How it works

**Generation**

```bash
npm run notices:generate
# writes docs/legal/NOTICES.md
